### PR TITLE
feat: add streaming output support for exec()

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ async def main():
         result = await sandbox.exec(["python", "-c", "print(2 + 2)"])
         print(result.stdout)  # 4
 
+        # Stream output in real-time to console
+        await sandbox.exec(["python", "train.py"], stream_output=True)
+
 asyncio.run(main())
 ```
 
@@ -40,6 +43,7 @@ asyncio.run(main())
 See the [examples/](examples/) directory for runnable scripts, or read the guides:
 
 - **[Basic Execution](docs/examples/basic-execution.md)** - `SandboxDefaults`, `exec()`, and file operations
+- **[Streaming Output](docs/examples/streaming-output.md)** - Real-time stdout/stderr streaming with callbacks
 - **[Function Decorator](docs/examples/function-decorator.md)** - Execute Python functions with `@session.function()`
 - **[Parallel Sandboxes](docs/examples/parallel-sandboxes.md)** - Manage multiple sandboxes concurrently
 

--- a/docs/examples/streaming-output.md
+++ b/docs/examples/streaming-output.md
@@ -1,0 +1,177 @@
+# Streaming Output
+
+This guide demonstrates how to stream stdout and stderr in real-time from sandbox commands, useful for long-running processes like training scripts or package installations.
+
+## Quick Start: Simple Streaming
+
+The simplest way to get real-time output is to add `stream_output=True` to `exec()`:
+
+```python
+import asyncio
+from aviato import Sandbox
+
+async def main():
+    async with Sandbox(
+        command="sleep",
+        args=["infinity"],
+        container_image="python:3.11",
+    ) as sandbox:
+        # Stream output directly to console
+        result = await sandbox.exec(["python", "train.py"], stream_output=True)
+        
+        print(f"Training complete! Exit code: {result.returncode}")
+
+asyncio.run(main())
+```
+
+This gives you:
+- **Real-time output** printed directly to stdout/stderr
+- **Complete result** returned with all output collected
+
+## Custom Callbacks
+
+For more control over how output is handled, use `on_stdout` and `on_stderr` callbacks:
+
+```python
+import asyncio
+from aviato import Sandbox
+
+async def main():
+    async with Sandbox(
+        command="sleep",
+        args=["infinity"],
+        container_image="python:3.11",
+    ) as sandbox:
+        # Custom handling of output
+        result = await sandbox.exec(
+            ["python", "train.py"],
+            on_stdout=lambda data: my_logger.info(data.decode()),
+            on_stderr=lambda data: my_logger.error(data.decode()),
+        )
+
+asyncio.run(main())
+```
+
+## Practical Examples
+
+### Progress Tracking
+
+```python
+async def install_with_progress(sandbox):
+    lines_received = 0
+    
+    def track_progress(data: bytes):
+        nonlocal lines_received
+        lines_received += data.count(b'\n')
+        print(f"\rLines received: {lines_received}", end="")
+    
+    result = await sandbox.exec(
+        ["pip", "install", "-r", "requirements.txt"],
+        on_stdout=track_progress,
+        on_stderr=track_progress,
+    )
+    
+    print(f"\nInstallation complete: {result.returncode}")
+    return result
+```
+
+### Separate Output Files
+
+```python
+async def exec_with_logging(sandbox, command):
+    with open("stdout.log", "wb") as stdout_file, \
+         open("stderr.log", "wb") as stderr_file:
+        
+        result = await sandbox.exec(
+            command,
+            on_stdout=lambda data: stdout_file.write(data),
+            on_stderr=lambda data: stderr_file.write(data),
+        )
+    
+    return result
+```
+
+### Real-Time Training Metrics
+
+```python
+import json
+
+async def monitor_training(sandbox):
+    metrics = []
+    
+    def parse_metrics(data: bytes):
+        text = data.decode()
+        for line in text.strip().split('\n'):
+            if line.startswith('{"epoch":'):
+                metrics.append(json.loads(line))
+                print(f"Epoch {metrics[-1]['epoch']}: loss={metrics[-1]['loss']:.4f}")
+    
+    result = await sandbox.exec(
+        ["python", "train.py", "--json-metrics"],
+        on_stdout=parse_metrics,
+    )
+    
+    return metrics
+```
+
+### Timeout with Partial Output
+
+```python
+from aviato import SandboxTimeoutError
+
+async def exec_with_timeout(sandbox, command, timeout=30):
+    output_so_far = []
+    
+    try:
+        result = await sandbox.exec(
+            command,
+            timeout_seconds=timeout,
+            on_stdout=lambda data: output_so_far.append(data),
+        )
+        return result
+    except SandboxTimeoutError:
+        print(f"Command timed out. Partial output received:")
+        print(b"".join(output_so_far).decode())
+        raise
+```
+
+## Error Handling
+
+Streaming methods raise the same exceptions as regular `exec()`:
+
+```python
+from aviato import SandboxExecutionError, SandboxTimeoutError
+
+try:
+    result = await sandbox.exec(
+        ["failing-command"],
+        check=True,  # Raise on non-zero exit
+        on_stdout=lambda data: print(data.decode(), end=""),
+    )
+except SandboxExecutionError as e:
+    print(f"Command failed: {e.exec_result.stderr}")
+except SandboxTimeoutError:
+    print("Command timed out")
+```
+
+## Best Practices
+
+1. **Flush output in your scripts**: Python buffers stdout by default. Use `sys.stdout.flush()` or run with `python -u` for unbuffered output.
+
+2. **Handle partial data**: Callbacks may receive partial lines. Buffer if you need complete lines:
+
+   ```python
+   buffer = ""
+   
+   def on_stdout(data: bytes):
+       nonlocal buffer
+       buffer += data.decode()
+       while '\n' in buffer:
+           line, buffer = buffer.split('\n', 1)
+           process_complete_line(line)
+   ```
+
+3. **Use appropriate timeouts**: Streaming connections can hang. Always set reasonable timeouts.
+
+4. **Prefer callbacks for simple cases**: Use `on_stdout`/`on_stderr` with `exec()` unless you need fine-grained chunk metadata.
+

--- a/examples/README.md
+++ b/examples/README.md
@@ -188,6 +188,19 @@ Demonstrates:
 - Client-side filtering after `Sandbox.list()`
 - Dry run mode for safe testing
 
+### Streaming Output (`streaming_output.py`)
+
+Real-time streaming of command output:
+
+```bash
+python examples/streaming_output.py
+```
+
+Demonstrates:
+- Simple streaming with `exec(stream_output=True)` to print to console
+- Streaming stdout/stderr with callbacks via `exec(on_stdout=..., on_stderr=...)`
+- Progress tracking for long-running commands
+
 ## API Patterns
 
 ### Quick Usage (Factory Method)
@@ -244,4 +257,16 @@ async with Sandbox.session(defaults) as session:
     
     result = await compute(2, 3)
     print(result.value)  # 5
+```
+
+### Streaming Output
+
+```python
+# Stream output in real-time with callbacks
+result = await sandbox.exec(
+    ["python", "train.py"],
+    on_stdout=lambda data: print(data.decode(), end=""),
+    on_stderr=lambda data: print(data.decode(), end="", file=sys.stderr),
+)
+print(f"Exit code: {result.returncode}")
 ```

--- a/examples/streaming_output.py
+++ b/examples/streaming_output.py
@@ -1,0 +1,146 @@
+"""Streaming output example for real-time command execution.
+
+This example demonstrates:
+- Simple streaming with stream_output=True (output goes directly to console)
+- Custom streaming callbacks for advanced use cases
+"""
+
+import asyncio
+
+from aviato import (
+    Sandbox,
+    SandboxDefaults,
+)
+
+
+async def example_simple_streaming() -> None:
+    """Stream output directly to console with stream_output=True.
+
+    This is the simplest way to see real-time output - just add stream_output=True.
+    Perfect for running training scripts where you want to watch progress.
+    """
+    print("=" * 60)
+    print("Example 1: Simple streaming with stream_output=True")
+    print("=" * 60)
+
+    defaults = SandboxDefaults(
+        container_image="python:3.11",
+        max_lifetime_seconds=60.0,
+    )
+
+    async with Sandbox(
+        command="sleep",
+        args=["infinity"],
+        defaults=defaults,
+    ) as sandbox:
+        print(f"Sandbox started: {sandbox.sandbox_id}\n")
+
+        # Define a simple Python script that produces output
+        script = """
+import sys
+
+for i in range(5):
+    print(f"Processing step {i + 1}/5...")
+    sys.stdout.flush()
+
+print("Done!", file=sys.stderr)
+sys.stderr.flush()
+"""
+
+        print("Running script with stream_output=True:\n", flush=True)
+
+        # Simply add stream_output=True - output goes directly to console
+        result = await sandbox.exec(["python", "-c", script], stream_output=True)
+
+        print(f"\nCommand completed with exit code: {result.returncode}")
+
+
+async def example_custom_callbacks() -> None:
+    """Use custom callbacks for advanced output handling.
+
+    Use on_stdout/on_stderr when you need to process output
+    (e.g., logging, parsing, filtering).
+    """
+    print("\n" + "=" * 60)
+    print("Example 2: Custom streaming callbacks")
+    print("=" * 60)
+
+    async with Sandbox(
+        command="sleep",
+        args=["infinity"],
+        container_image="python:3.11",
+    ) as sandbox:
+        print(f"Sandbox started: {sandbox.sandbox_id}\n")
+
+        script = """
+import sys
+print("INFO: Starting process")
+print("WARNING: Low memory", file=sys.stderr)
+print("INFO: Process complete")
+"""
+
+        print("Running with custom callbacks:\n", flush=True)
+
+        # Custom callbacks for processing output
+        result = await sandbox.exec(
+            ["python", "-c", script],
+            on_stdout=lambda data: print(f"[LOG] {data.decode()}", end=""),
+            on_stderr=lambda data: print(f"[ERR] {data.decode()}", end=""),
+        )
+
+        print(f"\nExit code: {result.returncode}")
+
+
+async def example_progress_tracking() -> None:
+    """Track progress of a long-running command.
+
+    This shows a practical use case: simulated training with epoch progress.
+    For simple "just show me the output" cases, use stream_output=True.
+    """
+    print("\n" + "=" * 60)
+    print("Example 3: Progress tracking (simulated training)")
+    print("=" * 60)
+
+    async with Sandbox(
+        command="sleep",
+        args=["infinity"],
+        container_image="python:3.11",
+    ) as sandbox:
+        print(f"Sandbox started: {sandbox.sandbox_id}\n")
+
+        # Simulated training script - outputs epoch progress with ~1s per epoch
+        training_script = """
+import random
+import time
+import sys
+
+for epoch in range(1, 6):
+    time.sleep(1)  # Simulate training time
+    loss = 2.5 / epoch + random.uniform(-0.1, 0.1)
+    acc = min(0.95, 0.5 + epoch * 0.09 + random.uniform(-0.02, 0.02))
+    print(f"Epoch {epoch}/5 | loss: {loss:.4f} | acc: {acc:.2%}", flush=True)
+"""
+
+        print("Running training with live output:\n", flush=True)
+
+        result = await sandbox.exec(
+            ["python", "-c", training_script],
+            stream_output=True,
+        )
+
+        print(f"\nTraining finished with exit code: {result.returncode}")
+
+
+async def main() -> None:
+    """Run all streaming examples."""
+    await example_simple_streaming()
+    await example_custom_callbacks()
+    await example_progress_tracking()
+
+    print("\n" + "=" * 60)
+    print("All examples completed!")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
 ]
 dependencies = [
     "coreweave-aviato-connectrpc-python==0.6.0.1.20251219221930+aab82cf11674",
+    "h2>=4.0.0",
     "pydantic>=2.0.0",
 ]
 

--- a/src/aviato/__init__.py
+++ b/src/aviato/__init__.py
@@ -4,7 +4,10 @@ from aviato._auth import WandbAuthError
 from aviato._defaults import SandboxDefaults
 from aviato._sandbox import Sandbox, SandboxStatus
 from aviato._session import Session
-from aviato._types import ExecResult, Serialization
+from aviato._types import (
+    ExecResult,
+    Serialization,
+)
 from aviato.exceptions import (
     AsyncFunctionError,
     AviatoAuthenticationError,

--- a/tests/integration/aviato/test_streaming.py
+++ b/tests/integration/aviato/test_streaming.py
@@ -1,0 +1,117 @@
+"""Integration tests for streaming functionality.
+
+These tests require a running Aviato backend with ATCStreamingService deployed.
+The streaming service uses HTTP/2 for bidirectional streaming.
+
+Set AVIATO_BASE_URL and authentication environment variables before running.
+"""
+
+import pytest
+
+from aviato import Sandbox
+
+
+@pytest.mark.asyncio
+async def test_exec_with_stdout_callback() -> None:
+    """Test exec() with on_stdout callback streams output in real-time."""
+    async with Sandbox(
+        command="sleep",
+        args=["infinity"],
+        container_image="python:3.11",
+    ) as sandbox:
+        stdout_chunks: list[bytes] = []
+
+        result = await sandbox.exec(
+            ["python", "-c", "print('hello'); print('world')"],
+            on_stdout=lambda data: stdout_chunks.append(data),
+        )
+
+        assert result.returncode == 0
+        assert result.stdout.strip() == "hello\nworld"
+        # Callback should have been called with the output
+        collected = b"".join(stdout_chunks)
+        assert b"hello" in collected
+        assert b"world" in collected
+
+
+@pytest.mark.asyncio
+async def test_exec_with_stderr_callback() -> None:
+    """Test exec() with on_stderr callback streams error output."""
+    async with Sandbox(
+        command="sleep",
+        args=["infinity"],
+        container_image="python:3.11",
+    ) as sandbox:
+        stderr_chunks: list[bytes] = []
+
+        result = await sandbox.exec(
+            ["python", "-c", "import sys; print('error', file=sys.stderr)"],
+            on_stderr=lambda data: stderr_chunks.append(data),
+        )
+
+        assert result.returncode == 0
+        assert "error" in result.stderr
+        # Callback should have been called with the error output
+        collected = b"".join(stderr_chunks)
+        assert b"error" in collected
+
+
+@pytest.mark.asyncio
+async def test_exec_with_both_callbacks() -> None:
+    """Test exec() with both stdout and stderr callbacks."""
+    async with Sandbox(
+        command="sleep",
+        args=["infinity"],
+        container_image="python:3.11",
+    ) as sandbox:
+        stdout_chunks: list[bytes] = []
+        stderr_chunks: list[bytes] = []
+
+        script = """
+import sys
+print('stdout line')
+sys.stdout.flush()
+print('stderr line', file=sys.stderr)
+sys.stderr.flush()
+"""
+
+        result = await sandbox.exec(
+            ["python", "-c", script],
+            on_stdout=lambda data: stdout_chunks.append(data),
+            on_stderr=lambda data: stderr_chunks.append(data),
+        )
+
+        assert result.returncode == 0
+        assert "stdout line" in result.stdout
+        assert "stderr line" in result.stderr
+
+        stdout_collected = b"".join(stdout_chunks)
+        stderr_collected = b"".join(stderr_chunks)
+        assert b"stdout line" in stdout_collected
+        assert b"stderr line" in stderr_collected
+
+
+@pytest.mark.asyncio
+async def test_exec_callback_with_check_raises() -> None:
+    """Test exec() with callback and check=True raises on failure."""
+    from aviato.exceptions import SandboxExecutionError
+
+    async with Sandbox(
+        command="sleep",
+        args=["infinity"],
+        container_image="python:3.11",
+    ) as sandbox:
+        stdout_chunks: list[bytes] = []
+
+        with pytest.raises(SandboxExecutionError) as exc_info:
+            await sandbox.exec(
+                ["sh", "-c", "echo 'before fail'; exit 1"],
+                check=True,
+                on_stdout=lambda data: stdout_chunks.append(data),
+            )
+
+        assert exc_info.value.exec_result is not None
+        assert exc_info.value.exec_result.returncode == 1
+        # Callback should still have received output before failure
+        collected = b"".join(stdout_chunks)
+        assert b"before fail" in collected

--- a/uv.lock
+++ b/uv.lock
@@ -31,6 +31,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "coreweave-aviato-connectrpc-python" },
+    { name = "h2" },
     { name = "pydantic" },
 ]
 
@@ -49,6 +50,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "coreweave-aviato-connectrpc-python", specifier = "==0.6.0.1.20251219221930+aab82cf11674" },
+    { name = "h2", specifier = ">=4.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
@@ -312,6 +314,28 @@ wheels = [
 ]
 
 [[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -337,6 +361,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR implements streaming output capabilities for the `exec()` method of aviato client SDK.

## Summary

Adds stdout/stderr streaming for sandbox command execution, shortening the feedback cycle for users, allowing them to see output as soon as it comes instead of all at once when the sandbox command completes.

### Changes

**New `exec()` parameters:**
- `stream_output=True` - Streams output directly to console (simplest usage)
- `on_stdout` / `on_stderr` - Custom callbacks for advanced use cases (logging, parsing, filtering)

**Implementation:**
- Added HTTP/2 streaming client for bidirectional streaming (half-duplex) with the ATCStreamingService
- Uses a queue to decouple httpx iteration from output processing (required for HTTP/2)

**Dependencies:**
- Added `h2>=4.0.0` for HTTP/2 support

### Usage

_Simple_: stream to console
```python
result = await sandbox.exec(["python", "train.py"], stream_output=True)
```

_Advanced_: custom callbacks  

```python
result = await sandbox.exec(
    ["python", "train.py"],
    on_stdout=lambda data: my_logger.info(data.decode()),
    on_stderr=lambda data: my_logger.error(data.decode()),
)
```

### Testing

- Unit tests for streaming path with mocked streaming client
- Integration tests covering stdout, stderr, combined callbacks, and error handling
- Manual testing with real training script simulations

### Documentation

- Updated README with streaming example
- New guide: `docs/examples/streaming-output.md`
- New example: `examples/streaming_output.py`
- Updated `examples/README.md` with streaming section

## Future

I've purposely left out the streaming logs implementation in this PR because I think there are still some backend issues to sort out. I ran into more EOF issues. I'll follow up in the new year with this functionality