### PR TITLE
chore: Add applied training as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for everything in the repo
+*       @coreweave/appliedtraining


### PR DESCRIPTION
https://github.com/orgs/coreweave/teams/appliedtraining

Also added the AT team as maintainers in the repo settings