### PR TITLE
feat(sdk): add infrastructure filtering and public service properties

### DIFF
--- a/src/aviato/_function.py
+++ b/src/aviato/_function.py
@@ -80,6 +80,8 @@ class RemoteFunction(Generic[P, R]):
         container_image: str | None = None,
         serialization: Serialization = Serialization.JSON,
         temp_dir: str = DEFAULT_TEMP_DIR,
+        runway_ids: list[str] | None = None,
+        tower_ids: list[str] | None = None,
         resources: dict[str, Any] | None = None,
         mounted_files: list[dict[str, Any]] | None = None,
         s3_mount: dict[str, Any] | None = None,
@@ -95,6 +97,8 @@ class RemoteFunction(Generic[P, R]):
             container_image: Override container image for this function
             serialization: Serialization mode (JSON by default for safety)
             temp_dir: Directory for temporary payload/result files in sandbox
+            runway_ids: Optional list of runway IDs
+            tower_ids: Optional list of tower IDs
             resources: Resource requests (CPU, memory, GPU)
             mounted_files: Files to mount into the sandbox
             s3_mount: S3 bucket mount configuration
@@ -119,6 +123,8 @@ class RemoteFunction(Generic[P, R]):
         self._container_image = container_image
         self._serialization = serialization
         self._temp_dir = temp_dir
+        self._runway_ids = list(runway_ids) if runway_ids is not None else None
+        self._tower_ids = list(tower_ids) if tower_ids is not None else None
         self._resources = resources
         self._mounted_files = mounted_files
         self._s3_mount = s3_mount
@@ -229,6 +235,10 @@ class RemoteFunction(Generic[P, R]):
         )
 
         sandbox_kwargs: dict[str, Any] = {}
+        if self._runway_ids is not None:
+            sandbox_kwargs["runway_ids"] = self._runway_ids
+        if self._tower_ids is not None:
+            sandbox_kwargs["tower_ids"] = self._tower_ids
         if self._resources is not None:
             sandbox_kwargs["resources"] = self._resources
         if self._mounted_files is not None:

--- a/src/aviato/_sandbox.py
+++ b/src/aviato/_sandbox.py
@@ -218,12 +218,19 @@ class Sandbox:
 
         self._tags: list[str] | None = self._defaults.merge_tags(tags)
 
-        self._runway_ids = runway_ids or (
-            list(self._defaults.runway_ids) if self._defaults.runway_ids else None
-        )
-        self._tower_ids = tower_ids or (
-            list(self._defaults.tower_ids) if self._defaults.tower_ids else None
-        )
+        if runway_ids is not None:
+            self._runway_ids = list(runway_ids)
+        elif self._defaults.runway_ids:
+            self._runway_ids = list(self._defaults.runway_ids)
+        else:
+            self._runway_ids = None
+
+        if tower_ids is not None:
+            self._tower_ids = list(tower_ids)
+        elif self._defaults.tower_ids:
+            self._tower_ids = list(self._defaults.tower_ids)
+        else:
+            self._tower_ids = None
 
         self._start_kwargs: dict[str, Any] = {}
         # Use explicit resources or fall back to defaults
@@ -271,6 +278,8 @@ class Sandbox:
         request_timeout_seconds: float | None = None,
         max_lifetime_seconds: float | None = None,
         tags: list[str] | None = None,
+        runway_ids: list[str] | None = None,
+        tower_ids: list[str] | None = None,
         resources: dict[str, Any] | None = None,
         mounted_files: list[dict[str, Any]] | None = None,
         s3_mount: dict[str, Any] | None = None,
@@ -292,6 +301,8 @@ class Sandbox:
             request_timeout_seconds: Timeout for API requests (client-side)
             max_lifetime_seconds: Max sandbox lifetime (server-side)
             tags: Optional tags for the sandbox
+            runway_ids: Optional list of runway IDs
+            tower_ids: Optional list of tower IDs
             resources: Resource requests (CPU, memory, GPU)
             mounted_files: Files to mount into the sandbox
             s3_mount: S3 bucket mount configuration
@@ -331,6 +342,8 @@ class Sandbox:
             request_timeout_seconds=request_timeout_seconds,
             max_lifetime_seconds=max_lifetime_seconds,
             tags=tags,
+            runway_ids=runway_ids,
+            tower_ids=tower_ids,
             resources=resources,
             mounted_files=mounted_files,
             s3_mount=s3_mount,
@@ -513,9 +526,9 @@ class Sandbox:
                 request_kwargs["tags"] = tags
             if status_enum:
                 request_kwargs["status"] = status_enum.to_proto()
-            if runway_ids:
+            if runway_ids is not None:
                 request_kwargs["runway_ids"] = runway_ids
-            if tower_ids:
+            if tower_ids is not None:
                 request_kwargs["tower_ids"] = tower_ids
 
             request = atc_pb2.ListSandboxesRequest(**request_kwargs)
@@ -1069,9 +1082,9 @@ class Sandbox:
 
             if self._max_lifetime_seconds is not None:
                 request_kwargs["max_lifetime_seconds"] = int(self._max_lifetime_seconds)
-            if self._runway_ids:
+            if self._runway_ids is not None:
                 request_kwargs["runway_ids"] = self._runway_ids
-            if self._tower_ids:
+            if self._tower_ids is not None:
                 request_kwargs["tower_ids"] = self._tower_ids
 
             request_kwargs.update(self._start_kwargs)

--- a/src/aviato/_session.py
+++ b/src/aviato/_session.py
@@ -161,6 +161,8 @@ class Session:
         args: list[str] | None = None,
         container_image: str | None = None,
         tags: list[str] | None = None,
+        runway_ids: list[str] | None = None,
+        tower_ids: list[str] | None = None,
         resources: dict[str, Any] | None = None,
         mounted_files: list[dict[str, Any]] | None = None,
         s3_mount: dict[str, Any] | None = None,
@@ -179,6 +181,8 @@ class Session:
             args: Arguments for the command
             container_image: Container image to use
             tags: Tags for the sandbox (merged with session defaults)
+            runway_ids: Optional list of runway IDs
+            tower_ids: Optional list of tower IDs
             resources: Resource requests (CPU, memory, GPU)
             mounted_files: Files to mount into the sandbox
             s3_mount: S3 bucket mount configuration
@@ -213,6 +217,8 @@ class Session:
             args=args,
             container_image=container_image,
             tags=tags,
+            runway_ids=runway_ids,
+            tower_ids=tower_ids,
             resources=resources,
             mounted_files=mounted_files,
             s3_mount=s3_mount,
@@ -296,12 +302,19 @@ class Session:
         merged_tags = self._defaults.merge_tags(tags)
 
         # Use session's default runway/tower IDs if not overridden
-        effective_runway_ids = runway_ids or (
-            list(self._defaults.runway_ids) if self._defaults.runway_ids else None
-        )
-        effective_tower_ids = tower_ids or (
-            list(self._defaults.tower_ids) if self._defaults.tower_ids else None
-        )
+        if runway_ids is not None:
+            effective_runway_ids = list(runway_ids)
+        elif self._defaults.runway_ids:
+            effective_runway_ids = list(self._defaults.runway_ids)
+        else:
+            effective_runway_ids = None
+
+        if tower_ids is not None:
+            effective_tower_ids = list(tower_ids)
+        elif self._defaults.tower_ids:
+            effective_tower_ids = list(self._defaults.tower_ids)
+        else:
+            effective_tower_ids = None
 
         sandboxes = await Sandbox._list_async(
             tags=merged_tags if merged_tags else None,
@@ -413,6 +426,8 @@ class Session:
         container_image: str | None = None,
         serialization: Serialization = Serialization.JSON,
         temp_dir: str | None = None,
+        runway_ids: builtins.list[str] | None = None,
+        tower_ids: builtins.list[str] | None = None,
         resources: dict[str, Any] | None = None,
         mounted_files: Sequence[dict[str, Any]] | None = None,
         s3_mount: dict[str, Any] | None = None,
@@ -434,6 +449,8 @@ class Session:
                 but only in trusted environments.
             temp_dir: Override temp directory for payload/result files in sandbox.
                 Defaults to session default. Created if missing.
+            runway_ids: Optional list of runway IDs
+            tower_ids: Optional list of tower IDs
             resources: Resource requests (CPU, memory, GPU)
             mounted_files: Files to mount into the sandbox
             s3_mount: S3 bucket mount configuration
@@ -479,6 +496,8 @@ class Session:
                 container_image=container_image,
                 serialization=serialization,
                 temp_dir=temp_dir or self._defaults.temp_dir,
+                runway_ids=runway_ids,
+                tower_ids=tower_ids,
                 resources=resources,
                 mounted_files=list(mounted_files) if mounted_files else None,
                 s3_mount=s3_mount,

--- a/tests/integration/aviato/test_sandbox.py
+++ b/tests/integration/aviato/test_sandbox.py
@@ -4,8 +4,10 @@ These tests require a running Aviato backend.
 Set AVIATO_BASE_URL and AVIATO_API_KEY environment variables before running.
 """
 
+import time
 import uuid
 
+import httpx
 import pytest
 
 from aviato import Sandbox, SandboxDefaults
@@ -360,3 +362,132 @@ async def test_sandbox_async_context_manager(sandbox_defaults: SandboxDefaults) 
 
     # After exiting, sandbox should be stopped
     # (sandbox._stopped should be True, but we can't easily verify this externally)
+
+
+# Infrastructure filtering tests (runway_ids, tower_ids)
+
+
+def test_sandbox_with_runway_and_tower_ids(sandbox_defaults: SandboxDefaults) -> None:
+    """Test sandbox creation with specific runway_ids and tower_ids.
+
+    Creates a sandbox to discover valid runway/tower IDs, then creates another
+    sandbox targeting those specific IDs to verify the parameters work.
+    """
+    # First, create a sandbox to discover valid infrastructure IDs
+    with Sandbox.run(defaults=sandbox_defaults) as discovery_sandbox:
+        discovery_sandbox.wait()
+        discovered_runway_id = discovery_sandbox.runway_id
+        discovered_tower_id = discovery_sandbox.tower_id
+
+        assert discovered_runway_id is not None, "Discovery sandbox should have runway_id"
+        assert discovered_tower_id is not None, "Discovery sandbox should have tower_id"
+
+        # Create a second sandbox targeting those specific IDs while first is still running
+        with Sandbox.run(
+            runway_ids=[discovered_runway_id],
+            tower_ids=[discovered_tower_id],
+            defaults=sandbox_defaults,
+        ) as targeted_sandbox:
+            targeted_sandbox.wait()
+
+            # Verify sandbox started successfully on the targeted infrastructure
+            assert targeted_sandbox.sandbox_id is not None
+            assert targeted_sandbox.status == "running"
+
+            # The sandbox should land on the specified runway/tower
+            assert targeted_sandbox.runway_id is not None
+            assert targeted_sandbox.tower_id is not None
+
+
+def test_sandbox_with_empty_runway_and_tower_ids(sandbox_defaults: SandboxDefaults) -> None:
+    """Test sandbox creation with empty runway_ids and tower_ids lists.
+
+    Verifies that empty lists are accepted (clearing any defaults).
+    """
+    with Sandbox.run(
+        runway_ids=[],
+        tower_ids=[],
+        defaults=sandbox_defaults,
+    ) as sandbox:
+        sandbox.wait()
+        assert sandbox.sandbox_id is not None
+        assert sandbox.status == "running"
+
+
+# Service address and exposed ports tests
+
+
+def test_sandbox_public_service_address(sandbox_defaults: SandboxDefaults) -> None:
+    """Test sandbox with public=True returns service_address.
+
+    Creates a sandbox with service={"public": True} and verifies that
+    service_address is populated in the response.
+    """
+    with Sandbox.run(
+        service={"public": True},
+        defaults=sandbox_defaults,
+    ) as sandbox:
+        sandbox.wait()
+
+        # service_address comes from StartSandboxResponse
+        # It may be None if the tower uses ClusterIP instead of LoadBalancer
+        if sandbox.service_address is not None:
+            # Address should look like "ip:port" or hostname format
+            assert ":" in sandbox.service_address or "." in sandbox.service_address
+        else:
+            # If service_address is None, that's acceptable - infrastructure dependent
+            # Just verify the sandbox is running and the property exists
+            assert sandbox.status == "running"
+
+
+def test_sandbox_public_exposed_ports(sandbox_defaults: SandboxDefaults) -> None:
+    """Test sandbox with public=True and ports returns exposed_ports.
+
+    Creates a sandbox with service={"public": True} and port mappings,
+    then verifies exposed_ports is populated.
+    """
+    with Sandbox.run(
+        service={"public": True},
+        ports=[{"container_port": 8080, "name": "http"}],
+        defaults=sandbox_defaults,
+    ) as sandbox:
+        sandbox.wait()
+
+        # exposed_ports comes from StartSandboxResponse
+        # It may be None depending on infrastructure configuration
+        if sandbox.exposed_ports is not None:
+            assert len(sandbox.exposed_ports) >= 1
+            # Each entry should be (port, name) tuple
+            port, name = sandbox.exposed_ports[0]
+            assert isinstance(port, int)
+            assert isinstance(name, str)
+        else:
+            # If exposed_ports is None, verify sandbox is running
+            assert sandbox.status == "running"
+
+
+def test_sandbox_public_service_connectivity(sandbox_defaults: SandboxDefaults) -> None:
+    """Test that exposed service is actually reachable.
+
+    Starts a simple HTTP server inside the sandbox and verifies we can
+    connect to it from outside using the service_address.
+    """
+    with Sandbox.run(
+        "python", "-m", "http.server", "8080",
+        service={"public": True},
+        ports=[{"container_port": 8080, "name": "http"}],
+        defaults=sandbox_defaults,
+    ) as sandbox:
+        sandbox.wait()
+
+        if sandbox.service_address is None:
+            pytest.skip("Infrastructure does not provide service_address")
+
+        # Give the HTTP server a moment to start
+        time.sleep(2)
+
+        response = httpx.get(
+            f"http://{sandbox.service_address}/",
+            timeout=120.0,
+        )
+        assert response.status_code == 200

--- a/tests/unit/aviato/test_sandbox.py
+++ b/tests/unit/aviato/test_sandbox.py
@@ -1196,3 +1196,61 @@ class TestSandboxServiceAddressAndExposedPorts:
 
                 assert sandbox.service_address is None
                 assert sandbox.exposed_ports is None
+
+
+class TestSandboxRunwayAndTowerIds:
+    """Tests for runway_ids and tower_ids parameters."""
+
+    def test_runway_ids_stored_on_sandbox(self) -> None:
+        """Test runway_ids are stored on sandbox instance."""
+        sandbox = Sandbox(runway_ids=["runway-1", "runway-2"])
+        assert sandbox._runway_ids == ["runway-1", "runway-2"]
+
+    def test_tower_ids_stored_on_sandbox(self) -> None:
+        """Test tower_ids are stored on sandbox instance."""
+        sandbox = Sandbox(tower_ids=["tower-1", "tower-2"])
+        assert sandbox._tower_ids == ["tower-1", "tower-2"]
+
+    def test_empty_runway_ids_overrides_defaults(self) -> None:
+        """Test empty runway_ids list overrides defaults."""
+        from aviato._defaults import SandboxDefaults
+
+        defaults = SandboxDefaults(runway_ids=("default-runway",))
+        sandbox = Sandbox(runway_ids=[], defaults=defaults)
+        assert sandbox._runway_ids == []
+
+    def test_empty_tower_ids_overrides_defaults(self) -> None:
+        """Test empty tower_ids list overrides defaults."""
+        from aviato._defaults import SandboxDefaults
+
+        defaults = SandboxDefaults(tower_ids=("default-tower",))
+        sandbox = Sandbox(tower_ids=[], defaults=defaults)
+        assert sandbox._tower_ids == []
+
+    def test_none_runway_ids_uses_defaults(self) -> None:
+        """Test None runway_ids falls back to defaults."""
+        from aviato._defaults import SandboxDefaults
+
+        defaults = SandboxDefaults(runway_ids=("default-runway",))
+        sandbox = Sandbox(defaults=defaults)
+        assert sandbox._runway_ids == ["default-runway"]
+
+    def test_none_tower_ids_uses_defaults(self) -> None:
+        """Test None tower_ids falls back to defaults."""
+        from aviato._defaults import SandboxDefaults
+
+        defaults = SandboxDefaults(tower_ids=("default-tower",))
+        sandbox = Sandbox(defaults=defaults)
+        assert sandbox._tower_ids == ["default-tower"]
+
+    def test_run_passes_runway_ids(self) -> None:
+        """Test Sandbox.run passes runway_ids to sandbox."""
+        with patch.object(Sandbox, "start"):
+            sandbox = Sandbox.run(runway_ids=["runway-1"])
+            assert sandbox._runway_ids == ["runway-1"]
+
+    def test_run_passes_tower_ids(self) -> None:
+        """Test Sandbox.run passes tower_ids to sandbox."""
+        with patch.object(Sandbox, "start"):
+            sandbox = Sandbox.run(tower_ids=["tower-1"])
+            assert sandbox._tower_ids == ["tower-1"]


### PR DESCRIPTION
Add parameters and properties for infrastructure targeting and public sandbox networking.

## Changes

**Infrastructure filtering:**
- Add `runway_ids` and `tower_ids` parameters to `Sandbox.run()`, `Session.sandbox()`, and `@session.function()`
- Allows targeting specific runways or towers when creating sandboxes

**Public service properties:**
- Add `service_address` and `exposed_ports` properties to `Sandbox`
- Populated when sandbox is created with `service={"public": True}`