### PR TITLE
feat(cli): add tower create-join-token command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,11 +120,11 @@ ignore_errors = true
 [[tool.mypy.overrides]]
 module = "wandb.*"
 ignore_missing_imports = true
+follow_imports = "skip"
 
 [[tool.mypy.overrides]]
 module = "kubernetes.*"
 ignore_missing_imports = true
-follow_imports = "skip"
 
 [tool.semantic_release]
 allow_zero_version      = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ cwsandbox = "cwsandbox.__main__:main"
 [project.optional-dependencies]
 cli = [
     "click>=8.0",
+    "httpx>=0.27.0",
+    "kubernetes>=28.0.0",
 ]
 dev = [
     "click>=8.0",
@@ -117,6 +119,10 @@ ignore_errors = true
 
 [[tool.mypy.overrides]]
 module = "wandb.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "kubernetes.*"
 ignore_missing_imports = true
 follow_imports = "skip"
 

--- a/src/cwsandbox/cli/__init__.py
+++ b/src/cwsandbox/cli/__init__.py
@@ -26,6 +26,7 @@ except ModuleNotFoundError as e:
 from cwsandbox.cli.exec import exec_command
 from cwsandbox.cli.list import list_sandboxes
 from cwsandbox.cli.logs import logs
+from cwsandbox.cli.tower import tower
 from cwsandbox.exceptions import CWSandboxError
 
 
@@ -52,3 +53,4 @@ def cli() -> None:
 cli.add_command(list_sandboxes, "ls")
 cli.add_command(exec_command, "exec")
 cli.add_command(logs, "logs")
+cli.add_command(tower, "tower")

--- a/src/cwsandbox/cli/tower.py
+++ b/src/cwsandbox/cli/tower.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: cwsandbox-client
+
+"""cwsandbox tower — tower management commands."""
+
+from __future__ import annotations
+
+import click
+
+from cwsandbox.cli.tower_create_join_token import create_join_token
+
+
+@click.group("tower")
+def tower() -> None:
+    """Tower management commands."""
+
+
+tower.add_command(create_join_token, "create-join-token")

--- a/src/cwsandbox/cli/tower_create_join_token.py
+++ b/src/cwsandbox/cli/tower_create_join_token.py
@@ -1,0 +1,290 @@
+# SPDX-FileCopyrightText: 2025 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: cwsandbox-client
+
+"""cwsandbox tower create-join-token — create a tower join token and store it in K8s."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import click
+
+DEFAULT_SECRET_NAME = "sandbox-tower-join-token"
+DEFAULT_SECRET_KEY = "token"
+DEFAULT_NAMESPACE = "sandbox-system"
+DEFAULT_ATC_SERVER = "https://atc.cw-sandbox.com"
+
+
+@click.command("create-join-token")
+@click.option(
+    "--tower-id",
+    default=None,
+    help="Tower ID to assign (required unless provided via --json).",
+)
+@click.option(
+    "--tower-group-id",
+    default=None,
+    help='Tower group for scheduling affinity (default: "default").',
+)
+@click.option(
+    "--ttl",
+    "ttl_seconds",
+    type=int,
+    default=None,
+    help="Token TTL in seconds (default: 86400 = 24 hours).",
+)
+@click.option("--description", default=None, help="Human-readable description for the token.")
+@click.option(
+    "--atc-server",
+    envvar="BOX_ATC_SERVER",
+    default=DEFAULT_ATC_SERVER,
+    show_envvar=True,
+    help="ATC server address.",
+)
+@click.option(
+    "--api-key",
+    envvar="BOX_API_KEY",
+    default=None,
+    show_envvar=True,
+    help="API key for ATC authentication.",
+)
+@click.option(
+    "--kubeconfig",
+    envvar="KUBECONFIG",
+    default=None,
+    show_envvar=True,
+    help="Path to kubeconfig file.",
+)
+@click.option(
+    "--namespace",
+    default=DEFAULT_NAMESPACE,
+    help="Kubernetes namespace for the secret.",
+)
+@click.option(
+    "--secret-name",
+    default=DEFAULT_SECRET_NAME,
+    help="Name of the Kubernetes secret.",
+)
+@click.option(
+    "--secret-key",
+    default=DEFAULT_SECRET_KEY,
+    help="Key within the Kubernetes secret.",
+)
+@click.option(
+    "--json",
+    "json_payload",
+    default=None,
+    help="JSON payload matching the API request format (use '-' to read from stdin).",
+)
+@click.option(
+    "--generate-only",
+    is_flag=True,
+    default=False,
+    help="Only generate the token and print it; do not store in Kubernetes.",
+)
+def create_join_token(
+    tower_id: str | None,
+    tower_group_id: str | None,
+    ttl_seconds: int | None,
+    description: str | None,
+    atc_server: str,
+    api_key: str | None,
+    kubeconfig: str | None,
+    namespace: str,
+    secret_name: str,
+    secret_key: str,
+    json_payload: str | None,
+    generate_only: bool,
+) -> None:
+    """Create a join token for a tower and store it in a Kubernetes secret.
+
+    Creates a join token by calling the ATC API, then stores the token
+    in a Kubernetes secret on the target cluster. The tower's Helm chart
+    reads this secret during the join process.
+
+    Examples:
+
+        cwsandbox tower create-join-token --tower-id=my-tower
+
+        cwsandbox tower create-join-token --tower-id=my-tower --namespace=sandbox-system
+
+        cwsandbox tower create-join-token --json='{"tower_id":"my-tower","ttl_seconds":3600}'
+
+        echo '{"tower_id":"my-tower"}' | cwsandbox tower create-join-token --json=-
+
+        cwsandbox tower create-join-token --tower-id=my-tower --generate-only
+    """
+    if not api_key:
+        raise click.ClickException("--api-key or BOX_API_KEY is required")
+
+    # If --json is provided, parse and use as base values (flags override)
+    if json_payload is not None:
+        tower_id, tower_group_id, ttl_seconds, description = _apply_json_payload(
+            json_payload, tower_id, tower_group_id, ttl_seconds, description
+        )
+
+    if not tower_id:
+        raise click.ClickException("--tower-id is required (via flag or JSON payload)")
+
+    # Build the API request body
+    body: dict[str, Any] = {"tower_id": tower_id}
+    if tower_group_id:
+        body["tower_group_id"] = tower_group_id
+    if ttl_seconds is not None:
+        body["ttl_seconds"] = ttl_seconds
+    if description:
+        body["description"] = description
+
+    token_resp = _create_token(atc_server, api_key, body)
+
+    if generate_only:
+        click.echo(f"Tower ID:       {token_resp.get('tower_id', '')}")
+        click.echo(f"Tower Group:    {token_resp.get('tower_group_id', '')}")
+        click.echo(f"Organization:   {token_resp.get('organization_id', '')}")
+        click.echo(f"Token ID:       {token_resp.get('token_id', '')}")
+        click.echo(f"Expires:        {token_resp.get('expires_at', '')}")
+        click.echo(f"Token:          {token_resp.get('token', '')}")
+        return
+
+    click.echo(
+        f"Created join token for tower {tower_id!r} "
+        f"(token_id: {token_resp.get('token_id', '')}, "
+        f"expires: {token_resp.get('expires_at', '')})",
+        err=True,
+    )
+
+    _store_token_in_secret(
+        token=token_resp["token"],
+        kubeconfig=kubeconfig,
+        namespace=namespace,
+        secret_name=secret_name,
+        secret_key=secret_key,
+    )
+
+    click.echo(
+        f"Stored join token in secret {namespace}/{secret_name} (key: {secret_key})",
+        err=True,
+    )
+
+
+def _apply_json_payload(
+    json_payload: str,
+    tower_id: str | None,
+    tower_group_id: str | None,
+    ttl_seconds: int | None,
+    description: str | None,
+) -> tuple[str | None, str | None, int | None, str | None]:
+    """Parse JSON payload and merge with flag values. Flags take precedence."""
+    if json_payload == "-":
+        data = sys.stdin.read()
+    else:
+        data = json_payload
+
+    try:
+        req = json.loads(data)
+    except json.JSONDecodeError as e:
+        raise click.ClickException(f"Invalid JSON: {e}") from None
+
+    if tower_id is None and req.get("tower_id"):
+        tower_id = req["tower_id"]
+    if tower_group_id is None and req.get("tower_group_id"):
+        tower_group_id = req["tower_group_id"]
+    if ttl_seconds is None and req.get("ttl_seconds"):
+        ttl_seconds = req["ttl_seconds"]
+    if description is None and req.get("description"):
+        description = req["description"]
+
+    return tower_id, tower_group_id, ttl_seconds, description
+
+
+def _create_token(atc_server: str, api_key: str, body: dict[str, Any]) -> dict[str, Any]:
+    """Call the ATC API to create a tower join token."""
+    try:
+        import httpx
+    except ModuleNotFoundError:
+        raise click.ClickException(
+            "httpx is required for this command. Install it with: pip install httpx"
+        ) from None
+
+    url = f"{atc_server.rstrip('/')}/v1beta1/towers/tokens"
+
+    try:
+        resp = httpx.post(
+            url,
+            json=body,
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=30.0,
+        )
+        resp.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        raise click.ClickException(
+            f"API error ({e.response.status_code}): {e.response.text}"
+        ) from None
+    except httpx.RequestError as e:
+        raise click.ClickException(f"Failed to connect to ATC: {e}") from None
+
+    return resp.json()  # type: ignore[no-any-return]
+
+
+def _store_token_in_secret(
+    *,
+    token: str,
+    kubeconfig: str | None,
+    namespace: str,
+    secret_name: str,
+    secret_key: str,
+) -> None:
+    """Store the join token in a Kubernetes secret."""
+    try:
+        from kubernetes import client as k8s_client
+        from kubernetes import config as k8s_config
+        from kubernetes.client.exceptions import ApiException
+    except ModuleNotFoundError:
+        raise click.ClickException(
+            "kubernetes client is required for this command. "
+            "Install it with: pip install kubernetes"
+        ) from None
+
+    # Load kubeconfig
+    try:
+        if kubeconfig:
+            k8s_config.load_kube_config(config_file=kubeconfig)
+        else:
+            k8s_config.load_kube_config()
+    except k8s_config.ConfigException:
+        try:
+            k8s_config.load_incluster_config()
+        except k8s_config.ConfigException:
+            raise click.ClickException(
+                "Could not load Kubernetes configuration. "
+                "Provide --kubeconfig or run inside a cluster."
+            ) from None
+
+    v1 = k8s_client.CoreV1Api()
+
+    secret = k8s_client.V1Secret(
+        metadata=k8s_client.V1ObjectMeta(
+            name=secret_name,
+            namespace=namespace,
+            labels={
+                "app.kubernetes.io/name": "sandbox-tower",
+                "app.kubernetes.io/component": "join-token",
+                "app.kubernetes.io/managed-by": "box",
+            },
+        ),
+        type="Opaque",
+        string_data={secret_key: token},
+    )
+
+    try:
+        v1.create_namespaced_secret(namespace=namespace, body=secret)
+    except ApiException as e:
+        if e.status == 409:
+            # Already exists — update it
+            v1.replace_namespaced_secret(name=secret_name, namespace=namespace, body=secret)
+            click.echo(f"Updated existing secret {namespace}/{secret_name}", err=True)
+        else:
+            raise click.ClickException(f"Failed to create Kubernetes secret: {e.reason}") from None

--- a/src/cwsandbox/cli/tower_create_join_token.py
+++ b/src/cwsandbox/cli/tower_create_join_token.py
@@ -15,7 +15,9 @@ import click
 DEFAULT_SECRET_NAME = "sandbox-tower-join-token"
 DEFAULT_SECRET_KEY = "token"
 DEFAULT_NAMESPACE = "sandbox-system"
-DEFAULT_ATC_SERVER = "https://atc.cw-sandbox.com"
+from cwsandbox._defaults import DEFAULT_BASE_URL
+
+DEFAULT_ATC_SERVER = DEFAULT_BASE_URL
 
 
 @click.command("create-join-token")
@@ -39,14 +41,14 @@ DEFAULT_ATC_SERVER = "https://atc.cw-sandbox.com"
 @click.option("--description", default=None, help="Human-readable description for the token.")
 @click.option(
     "--atc-server",
-    envvar="BOX_ATC_SERVER",
+    envvar="CWSANDBOX_BASE_URL",
     default=DEFAULT_ATC_SERVER,
     show_envvar=True,
     help="ATC server address.",
 )
 @click.option(
     "--api-key",
-    envvar="BOX_API_KEY",
+    envvar="CWSANDBOX_API_KEY",
     default=None,
     show_envvar=True,
     help="API key for ATC authentication.",
@@ -118,7 +120,7 @@ def create_join_token(
         cwsandbox tower create-join-token --tower-id=my-tower --generate-only
     """
     if not api_key:
-        raise click.ClickException("--api-key or BOX_API_KEY is required")
+        raise click.ClickException("--api-key or CWSANDBOX_API_KEY is required")
 
     # If --json is provided, parse and use as base values (flags override)
     if json_payload is not None:
@@ -131,11 +133,11 @@ def create_join_token(
 
     # Build the API request body
     body: dict[str, Any] = {"tower_id": tower_id}
-    if tower_group_id:
+    if tower_group_id is not None:
         body["tower_group_id"] = tower_group_id
     if ttl_seconds is not None:
         body["ttl_seconds"] = ttl_seconds
-    if description:
+    if description is not None:
         body["description"] = description
 
     token_resp = _create_token(atc_server, api_key, body)
@@ -156,8 +158,12 @@ def create_join_token(
         err=True,
     )
 
+    token = token_resp.get("token")
+    if not token:
+        raise click.ClickException("ATC returned invalid response: missing 'token' field")
+
     _store_token_in_secret(
-        token=token_resp["token"],
+        token=token,
         kubeconfig=kubeconfig,
         namespace=namespace,
         secret_name=secret_name,
@@ -188,13 +194,13 @@ def _apply_json_payload(
     except json.JSONDecodeError as e:
         raise click.ClickException(f"Invalid JSON: {e}") from None
 
-    if tower_id is None and req.get("tower_id"):
+    if tower_id is None and req.get("tower_id") is not None:
         tower_id = req["tower_id"]
-    if tower_group_id is None and req.get("tower_group_id"):
+    if tower_group_id is None and req.get("tower_group_id") is not None:
         tower_group_id = req["tower_group_id"]
-    if ttl_seconds is None and req.get("ttl_seconds"):
+    if ttl_seconds is None and req.get("ttl_seconds") is not None:
         ttl_seconds = req["ttl_seconds"]
-    if description is None and req.get("description"):
+    if description is None and req.get("description") is not None:
         description = req["description"]
 
     return tower_id, tower_group_id, ttl_seconds, description

--- a/src/cwsandbox/cli/tower_create_join_token.py
+++ b/src/cwsandbox/cli/tower_create_join_token.py
@@ -12,11 +12,11 @@ from typing import Any
 
 import click
 
+from cwsandbox._defaults import DEFAULT_BASE_URL
+
 DEFAULT_SECRET_NAME = "sandbox-tower-join-token"
 DEFAULT_SECRET_KEY = "token"
 DEFAULT_NAMESPACE = "sandbox-system"
-from cwsandbox._defaults import DEFAULT_BASE_URL
-
 DEFAULT_ATC_SERVER = DEFAULT_BASE_URL
 
 

--- a/tests/unit/cwsandbox/test_cli_tower_create_join_token.py
+++ b/tests/unit/cwsandbox/test_cli_tower_create_join_token.py
@@ -66,10 +66,13 @@ class TestCreateJoinTokenValidation:
     def test_api_key_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """CWSANDBOX_API_KEY env var is accepted."""
         monkeypatch.setenv("CWSANDBOX_API_KEY", "env-key")
-        with patch(
-            "cwsandbox.cli.tower_create_join_token._create_token",
-            return_value=_TOKEN_RESPONSE,
-        ), patch("cwsandbox.cli.tower_create_join_token._store_token_in_secret"):
+        with (
+            patch(
+                "cwsandbox.cli.tower_create_join_token._create_token",
+                return_value=_TOKEN_RESPONSE,
+            ),
+            patch("cwsandbox.cli.tower_create_join_token._store_token_in_secret"),
+        ):
             result = _invoke(["--tower-id=my-tower"])
         assert result.exit_code == 0
 
@@ -116,17 +119,17 @@ class TestCreateJoinTokenNormalFlow:
 
     @patch("cwsandbox.cli.tower_create_join_token._store_token_in_secret")
     @patch("cwsandbox.cli.tower_create_join_token._create_token", return_value=_TOKEN_RESPONSE)
-    def test_custom_k8s_options(
-        self, mock_create: MagicMock, mock_store: MagicMock
-    ) -> None:
-        result = _invoke([
-            "--tower-id=my-tower",
-            "--api-key=test-key",
-            "--namespace=custom-ns",
-            "--secret-name=my-secret",
-            "--secret-key=my-key",
-            "--kubeconfig=/tmp/kubeconfig",
-        ])
+    def test_custom_k8s_options(self, mock_create: MagicMock, mock_store: MagicMock) -> None:
+        result = _invoke(
+            [
+                "--tower-id=my-tower",
+                "--api-key=test-key",
+                "--namespace=custom-ns",
+                "--secret-name=my-secret",
+                "--secret-key=my-key",
+                "--kubeconfig=/tmp/kubeconfig",
+            ]
+        )
         assert result.exit_code == 0
         mock_store.assert_called_once_with(
             token="secret-join-token-value",
@@ -141,13 +144,15 @@ class TestCreateJoinTokenNormalFlow:
     def test_request_body_includes_optional_fields(
         self, mock_create: MagicMock, mock_store: MagicMock
     ) -> None:
-        result = _invoke([
-            "--tower-id=my-tower",
-            "--api-key=test-key",
-            "--tower-group-id=gpu-group",
-            "--ttl=3600",
-            "--description=test token",
-        ])
+        result = _invoke(
+            [
+                "--tower-id=my-tower",
+                "--api-key=test-key",
+                "--tower-group-id=gpu-group",
+                "--ttl=3600",
+                "--description=test token",
+            ]
+        )
         assert result.exit_code == 0
         body = mock_create.call_args[0][2]
         assert body == {
@@ -159,9 +164,7 @@ class TestCreateJoinTokenNormalFlow:
 
     @patch("cwsandbox.cli.tower_create_join_token._store_token_in_secret")
     @patch("cwsandbox.cli.tower_create_join_token._create_token")
-    def test_missing_token_in_response(
-        self, mock_create: MagicMock, mock_store: MagicMock
-    ) -> None:
+    def test_missing_token_in_response(self, mock_create: MagicMock, mock_store: MagicMock) -> None:
         mock_create.return_value = {"tower_id": "my-tower"}
         result = _invoke(["--tower-id=my-tower", "--api-key=test-key"])
         assert result.exit_code == 1
@@ -174,13 +177,13 @@ class TestJsonPayload:
 
     @patch("cwsandbox.cli.tower_create_join_token._store_token_in_secret")
     @patch("cwsandbox.cli.tower_create_join_token._create_token", return_value=_TOKEN_RESPONSE)
-    def test_json_provides_tower_id(
-        self, mock_create: MagicMock, mock_store: MagicMock
-    ) -> None:
-        result = _invoke([
-            "--api-key=test-key",
-            '--json={"tower_id":"json-tower","ttl_seconds":7200}',
-        ])
+    def test_json_provides_tower_id(self, mock_create: MagicMock, mock_store: MagicMock) -> None:
+        result = _invoke(
+            [
+                "--api-key=test-key",
+                '--json={"tower_id":"json-tower","ttl_seconds":7200}',
+            ]
+        )
         assert result.exit_code == 0
         body = mock_create.call_args[0][2]
         assert body["tower_id"] == "json-tower"
@@ -188,14 +191,14 @@ class TestJsonPayload:
 
     @patch("cwsandbox.cli.tower_create_join_token._store_token_in_secret")
     @patch("cwsandbox.cli.tower_create_join_token._create_token", return_value=_TOKEN_RESPONSE)
-    def test_flags_override_json(
-        self, mock_create: MagicMock, mock_store: MagicMock
-    ) -> None:
-        result = _invoke([
-            "--tower-id=flag-tower",
-            "--api-key=test-key",
-            '--json={"tower_id":"json-tower","ttl_seconds":7200}',
-        ])
+    def test_flags_override_json(self, mock_create: MagicMock, mock_store: MagicMock) -> None:
+        result = _invoke(
+            [
+                "--tower-id=flag-tower",
+                "--api-key=test-key",
+                '--json={"tower_id":"json-tower","ttl_seconds":7200}',
+            ]
+        )
         assert result.exit_code == 0
         body = mock_create.call_args[0][2]
         assert body["tower_id"] == "flag-tower"
@@ -213,14 +216,14 @@ class TestJsonPayload:
 
     @patch("cwsandbox.cli.tower_create_join_token._store_token_in_secret")
     @patch("cwsandbox.cli.tower_create_join_token._create_token", return_value=_TOKEN_RESPONSE)
-    def test_json_ttl_zero_not_dropped(
-        self, mock_create: MagicMock, mock_store: MagicMock
-    ) -> None:
+    def test_json_ttl_zero_not_dropped(self, mock_create: MagicMock, mock_store: MagicMock) -> None:
         """ttl_seconds=0 in JSON should not be silently dropped."""
-        result = _invoke([
-            "--api-key=test-key",
-            '--json={"tower_id":"my-tower","ttl_seconds":0}',
-        ])
+        result = _invoke(
+            [
+                "--api-key=test-key",
+                '--json={"tower_id":"my-tower","ttl_seconds":0}',
+            ]
+        )
         assert result.exit_code == 0
         body = mock_create.call_args[0][2]
         assert body["ttl_seconds"] == 0
@@ -231,10 +234,12 @@ class TestJsonPayload:
         self, mock_create: MagicMock, mock_store: MagicMock
     ) -> None:
         """Empty string description from JSON should be passed through."""
-        result = _invoke([
-            "--api-key=test-key",
-            '--json={"tower_id":"my-tower","description":""}',
-        ])
+        result = _invoke(
+            [
+                "--api-key=test-key",
+                '--json={"tower_id":"my-tower","description":""}',
+            ]
+        )
         assert result.exit_code == 0
         body = mock_create.call_args[0][2]
         assert body["description"] == ""
@@ -277,8 +282,9 @@ class TestStoreTokenInSecret:
     def test_secret_creation_success(self, mock_create: MagicMock) -> None:
         from kubernetes.client import CoreV1Api
 
-        with patch.object(CoreV1Api, "create_namespaced_secret") as mock_create_secret, patch(
-            "kubernetes.config.load_kube_config"
+        with (
+            patch.object(CoreV1Api, "create_namespaced_secret") as mock_create_secret,
+            patch("kubernetes.config.load_kube_config"),
         ):
             result = _invoke(["--tower-id=my-tower", "--api-key=test-key"])
 
@@ -292,11 +298,11 @@ class TestStoreTokenInSecret:
 
         api_exc = ApiException(status=409, reason="Conflict")
 
-        with patch.object(
-            CoreV1Api, "create_namespaced_secret", side_effect=api_exc
-        ), patch.object(
-            CoreV1Api, "replace_namespaced_secret"
-        ) as mock_replace, patch("kubernetes.config.load_kube_config"):
+        with (
+            patch.object(CoreV1Api, "create_namespaced_secret", side_effect=api_exc),
+            patch.object(CoreV1Api, "replace_namespaced_secret") as mock_replace,
+            patch("kubernetes.config.load_kube_config"),
+        ):
             result = _invoke(["--tower-id=my-tower", "--api-key=test-key"])
 
         assert result.exit_code == 0

--- a/tests/unit/cwsandbox/test_cli_tower_create_join_token.py
+++ b/tests/unit/cwsandbox/test_cli_tower_create_join_token.py
@@ -13,7 +13,6 @@ from click.testing import CliRunner
 
 from cwsandbox.cli import cli
 
-
 # Shared mock API response
 _TOKEN_RESPONSE = {
     "tower_id": "my-tower",

--- a/tests/unit/cwsandbox/test_cli_tower_create_join_token.py
+++ b/tests/unit/cwsandbox/test_cli_tower_create_join_token.py
@@ -1,0 +1,303 @@
+# SPDX-FileCopyrightText: 2025 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: cwsandbox-client
+
+"""Tests for cwsandbox tower create-join-token CLI command."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from cwsandbox.cli import cli
+
+
+# Shared mock API response
+_TOKEN_RESPONSE = {
+    "tower_id": "my-tower",
+    "tower_group_id": "default",
+    "organization_id": "org-123",
+    "token_id": "tok-abc",
+    "expires_at": "2026-03-18T00:00:00Z",
+    "token": "secret-join-token-value",
+}
+
+
+def _invoke(args: list[str], *, input: str | None = None) -> object:
+    """Run the CLI with the given args."""
+    runner = CliRunner()
+    return runner.invoke(cli, ["tower", "create-join-token"] + args, input=input)
+
+
+class TestCreateJoinTokenHelp:
+    """Basic CLI registration tests."""
+
+    def test_help_exits_zero(self) -> None:
+        result = _invoke(["--help"])
+        assert result.exit_code == 0
+        assert "Create a join token" in result.output
+
+
+class TestCreateJoinTokenValidation:
+    """Input validation tests."""
+
+    def test_missing_api_key(self) -> None:
+        result = _invoke(["--tower-id=my-tower"])
+        assert result.exit_code == 1
+        assert "--api-key or CWSANDBOX_API_KEY" in result.output
+
+    def test_missing_tower_id(self) -> None:
+        result = _invoke(["--api-key=test-key"])
+        assert result.exit_code == 1
+        assert "--tower-id is required" in result.output
+
+    def test_missing_tower_id_empty_json(self) -> None:
+        result = _invoke(["--api-key=test-key", "--json={}"])
+        assert result.exit_code == 1
+        assert "--tower-id is required" in result.output
+
+    def test_invalid_json(self) -> None:
+        result = _invoke(["--api-key=test-key", "--json=not-json"])
+        assert result.exit_code == 1
+        assert "Invalid JSON" in result.output
+
+    def test_api_key_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """CWSANDBOX_API_KEY env var is accepted."""
+        monkeypatch.setenv("CWSANDBOX_API_KEY", "env-key")
+        with patch(
+            "cwsandbox.cli.tower_create_join_token._create_token",
+            return_value=_TOKEN_RESPONSE,
+        ), patch("cwsandbox.cli.tower_create_join_token._store_token_in_secret"):
+            result = _invoke(["--tower-id=my-tower"])
+        assert result.exit_code == 0
+
+
+class TestCreateJoinTokenGenerateOnly:
+    """Tests for --generate-only mode."""
+
+    @patch("cwsandbox.cli.tower_create_join_token._create_token", return_value=_TOKEN_RESPONSE)
+    def test_generate_only_prints_token_info(self, mock_create: MagicMock) -> None:
+        result = _invoke(["--tower-id=my-tower", "--api-key=test-key", "--generate-only"])
+        assert result.exit_code == 0
+        assert "Tower ID:       my-tower" in result.output
+        assert "Token:          secret-join-token-value" in result.output
+        assert "Token ID:       tok-abc" in result.output
+
+    @patch("cwsandbox.cli.tower_create_join_token._create_token", return_value=_TOKEN_RESPONSE)
+    @patch("cwsandbox.cli.tower_create_join_token._store_token_in_secret")
+    def test_generate_only_does_not_store(
+        self, mock_store: MagicMock, mock_create: MagicMock
+    ) -> None:
+        result = _invoke(["--tower-id=my-tower", "--api-key=test-key", "--generate-only"])
+        assert result.exit_code == 0
+        mock_store.assert_not_called()
+
+
+class TestCreateJoinTokenNormalFlow:
+    """Tests for the normal (non-generate-only) flow."""
+
+    @patch("cwsandbox.cli.tower_create_join_token._store_token_in_secret")
+    @patch("cwsandbox.cli.tower_create_join_token._create_token", return_value=_TOKEN_RESPONSE)
+    def test_creates_token_and_stores_secret(
+        self, mock_create: MagicMock, mock_store: MagicMock
+    ) -> None:
+        result = _invoke(["--tower-id=my-tower", "--api-key=test-key"])
+        assert result.exit_code == 0
+        mock_create.assert_called_once()
+        mock_store.assert_called_once_with(
+            token="secret-join-token-value",
+            kubeconfig=None,
+            namespace="sandbox-system",
+            secret_name="sandbox-tower-join-token",
+            secret_key="token",
+        )
+
+    @patch("cwsandbox.cli.tower_create_join_token._store_token_in_secret")
+    @patch("cwsandbox.cli.tower_create_join_token._create_token", return_value=_TOKEN_RESPONSE)
+    def test_custom_k8s_options(
+        self, mock_create: MagicMock, mock_store: MagicMock
+    ) -> None:
+        result = _invoke([
+            "--tower-id=my-tower",
+            "--api-key=test-key",
+            "--namespace=custom-ns",
+            "--secret-name=my-secret",
+            "--secret-key=my-key",
+            "--kubeconfig=/tmp/kubeconfig",
+        ])
+        assert result.exit_code == 0
+        mock_store.assert_called_once_with(
+            token="secret-join-token-value",
+            kubeconfig="/tmp/kubeconfig",
+            namespace="custom-ns",
+            secret_name="my-secret",
+            secret_key="my-key",
+        )
+
+    @patch("cwsandbox.cli.tower_create_join_token._store_token_in_secret")
+    @patch("cwsandbox.cli.tower_create_join_token._create_token", return_value=_TOKEN_RESPONSE)
+    def test_request_body_includes_optional_fields(
+        self, mock_create: MagicMock, mock_store: MagicMock
+    ) -> None:
+        result = _invoke([
+            "--tower-id=my-tower",
+            "--api-key=test-key",
+            "--tower-group-id=gpu-group",
+            "--ttl=3600",
+            "--description=test token",
+        ])
+        assert result.exit_code == 0
+        body = mock_create.call_args[0][2]
+        assert body == {
+            "tower_id": "my-tower",
+            "tower_group_id": "gpu-group",
+            "ttl_seconds": 3600,
+            "description": "test token",
+        }
+
+    @patch("cwsandbox.cli.tower_create_join_token._store_token_in_secret")
+    @patch("cwsandbox.cli.tower_create_join_token._create_token")
+    def test_missing_token_in_response(
+        self, mock_create: MagicMock, mock_store: MagicMock
+    ) -> None:
+        mock_create.return_value = {"tower_id": "my-tower"}
+        result = _invoke(["--tower-id=my-tower", "--api-key=test-key"])
+        assert result.exit_code == 1
+        assert "missing 'token' field" in result.output
+        mock_store.assert_not_called()
+
+
+class TestJsonPayload:
+    """Tests for --json payload parsing and flag precedence."""
+
+    @patch("cwsandbox.cli.tower_create_join_token._store_token_in_secret")
+    @patch("cwsandbox.cli.tower_create_join_token._create_token", return_value=_TOKEN_RESPONSE)
+    def test_json_provides_tower_id(
+        self, mock_create: MagicMock, mock_store: MagicMock
+    ) -> None:
+        result = _invoke([
+            "--api-key=test-key",
+            '--json={"tower_id":"json-tower","ttl_seconds":7200}',
+        ])
+        assert result.exit_code == 0
+        body = mock_create.call_args[0][2]
+        assert body["tower_id"] == "json-tower"
+        assert body["ttl_seconds"] == 7200
+
+    @patch("cwsandbox.cli.tower_create_join_token._store_token_in_secret")
+    @patch("cwsandbox.cli.tower_create_join_token._create_token", return_value=_TOKEN_RESPONSE)
+    def test_flags_override_json(
+        self, mock_create: MagicMock, mock_store: MagicMock
+    ) -> None:
+        result = _invoke([
+            "--tower-id=flag-tower",
+            "--api-key=test-key",
+            '--json={"tower_id":"json-tower","ttl_seconds":7200}',
+        ])
+        assert result.exit_code == 0
+        body = mock_create.call_args[0][2]
+        assert body["tower_id"] == "flag-tower"
+
+    @patch("cwsandbox.cli.tower_create_join_token._store_token_in_secret")
+    @patch("cwsandbox.cli.tower_create_join_token._create_token", return_value=_TOKEN_RESPONSE)
+    def test_json_stdin(self, mock_create: MagicMock, mock_store: MagicMock) -> None:
+        result = _invoke(
+            ["--api-key=test-key", "--json=-"],
+            input='{"tower_id":"stdin-tower"}',
+        )
+        assert result.exit_code == 0
+        body = mock_create.call_args[0][2]
+        assert body["tower_id"] == "stdin-tower"
+
+    @patch("cwsandbox.cli.tower_create_join_token._store_token_in_secret")
+    @patch("cwsandbox.cli.tower_create_join_token._create_token", return_value=_TOKEN_RESPONSE)
+    def test_json_ttl_zero_not_dropped(
+        self, mock_create: MagicMock, mock_store: MagicMock
+    ) -> None:
+        """ttl_seconds=0 in JSON should not be silently dropped."""
+        result = _invoke([
+            "--api-key=test-key",
+            '--json={"tower_id":"my-tower","ttl_seconds":0}',
+        ])
+        assert result.exit_code == 0
+        body = mock_create.call_args[0][2]
+        assert body["ttl_seconds"] == 0
+
+    @patch("cwsandbox.cli.tower_create_join_token._store_token_in_secret")
+    @patch("cwsandbox.cli.tower_create_join_token._create_token", return_value=_TOKEN_RESPONSE)
+    def test_json_empty_string_description_not_dropped(
+        self, mock_create: MagicMock, mock_store: MagicMock
+    ) -> None:
+        """Empty string description from JSON should be passed through."""
+        result = _invoke([
+            "--api-key=test-key",
+            '--json={"tower_id":"my-tower","description":""}',
+        ])
+        assert result.exit_code == 0
+        body = mock_create.call_args[0][2]
+        assert body["description"] == ""
+
+
+class TestCreateToken:
+    """Tests for _create_token helper."""
+
+    def test_http_status_error(self) -> None:
+        import httpx
+
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        mock_response.text = "Forbidden"
+
+        with patch("httpx.post") as mock_post:
+            mock_post.side_effect = httpx.HTTPStatusError(
+                "error", request=MagicMock(), response=mock_response
+            )
+            result = _invoke(["--tower-id=my-tower", "--api-key=test-key"])
+
+        assert result.exit_code == 1
+        assert "API error (403)" in result.output
+
+    def test_request_error(self) -> None:
+        import httpx
+
+        with patch("httpx.post") as mock_post:
+            mock_post.side_effect = httpx.RequestError("connection refused")
+            result = _invoke(["--tower-id=my-tower", "--api-key=test-key"])
+
+        assert result.exit_code == 1
+        assert "Failed to connect to ATC" in result.output
+
+
+class TestStoreTokenInSecret:
+    """Tests for _store_token_in_secret helper."""
+
+    @patch("cwsandbox.cli.tower_create_join_token._create_token", return_value=_TOKEN_RESPONSE)
+    def test_secret_creation_success(self, mock_create: MagicMock) -> None:
+        from kubernetes.client import CoreV1Api
+
+        with patch.object(CoreV1Api, "create_namespaced_secret") as mock_create_secret, patch(
+            "kubernetes.config.load_kube_config"
+        ):
+            result = _invoke(["--tower-id=my-tower", "--api-key=test-key"])
+
+        assert result.exit_code == 0
+        mock_create_secret.assert_called_once()
+
+    @patch("cwsandbox.cli.tower_create_join_token._create_token", return_value=_TOKEN_RESPONSE)
+    def test_secret_409_triggers_update(self, mock_create: MagicMock) -> None:
+        from kubernetes.client import CoreV1Api
+        from kubernetes.client.exceptions import ApiException
+
+        api_exc = ApiException(status=409, reason="Conflict")
+
+        with patch.object(
+            CoreV1Api, "create_namespaced_secret", side_effect=api_exc
+        ), patch.object(
+            CoreV1Api, "replace_namespaced_secret"
+        ) as mock_replace, patch("kubernetes.config.load_kube_config"):
+            result = _invoke(["--tower-id=my-tower", "--api-key=test-key"])
+
+        assert result.exit_code == 0
+        mock_replace.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -247,6 +247,8 @@ dependencies = [
 [package.optional-dependencies]
 cli = [
     { name = "click" },
+    { name = "httpx" },
+    { name = "kubernetes" },
 ]
 dev = [
     { name = "click" },
@@ -278,7 +280,9 @@ requires-dist = [
     { name = "googleapis-common-protos", specifier = ">=1.63.0" },
     { name = "grpc-stubs", marker = "extra == 'dev'", specifier = ">=1.53.0" },
     { name = "grpcio", specifier = ">=1.78.0" },
+    { name = "httpx", marker = "extra == 'cli'", specifier = ">=0.27.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
+    { name = "kubernetes", marker = "extra == 'cli'", specifier = ">=28.0.0" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6.0" },
     { name = "mkdocs-include-markdown-plugin", marker = "extra == 'docs'", specifier = ">=7.0.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5.0" },
@@ -327,6 +331,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6a/ab/88d67f02024700b48cd8232579ad1316aa9df2272c63049c27cc094229d6/dotty_dict-1.3.1.tar.gz", hash = "sha256:4b016e03b8ae265539757a53eba24b9bfda506fb94fbce0bee843c6f05541a15", size = 7699, upload-time = "2022-07-09T18:50:57.727Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/91/e0d457ee03ec33d79ee2cd8d212debb1bc21dfb99728ae35efdb5832dc22/dotty_dict-1.3.1-py3-none-any.whl", hash = "sha256:5022d234d9922f13aa711b4950372a06a6d64cb6d6db9ba43d0ba133ebfce31f", size = 7014, upload-time = "2022-07-09T18:50:55.058Z" },
+]
+
+[[package]]
+name = "durationpy"
+version = "0.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/a4/e44218c2b394e31a6dd0d6b095c4e1f32d0be54c2a4b250032d717647bab/durationpy-0.10.tar.gz", hash = "sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba", size = 3335, upload-time = "2025-05-17T13:52:37.26Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl", hash = "sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286", size = 3922, upload-time = "2025-05-17T13:52:36.463Z" },
 ]
 
 [[package]]
@@ -543,6 +556,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "kubernetes"
+version = "35.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "durationpy" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "requests-oauthlib" },
+    { name = "six" },
+    { name = "urllib3" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/8f/85bf51ad4150f64e8c665daf0d9dfe9787ae92005efb9a4d1cba592bd79d/kubernetes-35.0.0.tar.gz", hash = "sha256:3d00d344944239821458b9efd484d6df9f011da367ecb155dadf9513f05f09ee", size = 1094642, upload-time = "2026-01-16T01:05:27.76Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/70/05b685ea2dffcb2adbf3cdcea5d8865b7bc66f67249084cf845012a0ff13/kubernetes-35.0.0-py2.py3-none-any.whl", hash = "sha256:39e2b33b46e5834ef6c3985ebfe2047ab39135d41de51ce7641a7ca5b372a13d", size = 2017602, upload-time = "2026-01-16T01:05:25.991Z" },
 ]
 
 [[package]]
@@ -858,6 +891,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
 ]
 
 [[package]]
@@ -1234,6 +1276,19 @@ wheels = [
 ]
 
 [[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
 name = "requests-toolbelt"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1485,6 +1540,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/79/3e/c0bdc27cf06f4e47680bd5803a07cb3dfd17de84cde92dd217dcb9e05253/wcmatch-10.1.tar.gz", hash = "sha256:f11f94208c8c8484a16f4f48638a85d771d9513f4ab3f37595978801cb9465af", size = 117421, upload-time = "2025-06-22T19:14:02.49Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/d8/0d1d2e9d3fabcf5d6840362adcf05f8cf3cd06a73358140c3a97189238ae/wcmatch-10.1-py3-none-any.whl", hash = "sha256:5848ace7dbb0476e5e55ab63c6bbd529745089343427caa5537f230cc01beb8a", size = 39854, upload-time = "2025-06-22T19:14:00.978Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `cwsandbox tower create-join-token` CLI command for creating join tokens and storing them in Kubernetes secrets
- Calls `POST /v1beta1/towers/tokens` to generate a single-use tower join token
- Stores the token in a K8s Opaque secret (default name: `sandbox-tower-join-token`, key: `token`) matching the sandbox-tower Helm chart expectations
- Supports `--json` flag for passing an API-compatible JSON payload (inline string or `-` for stdin)
- Supports `--generate-only` to print token details without creating a K8s secret
- Adds `httpx` and `kubernetes` as optional `[cli]` dependencies

## Usage

```bash
# Basic usage
cwsandbox tower create-join-token --tower-id=my-tower --api-key=<key>

# With JSON payload
cwsandbox tower create-join-token --json='{"tower_id":"my-tower","ttl_seconds":3600}'

# Generate only (no K8s secret)
cwsandbox tower create-join-token --tower-id=my-tower --generate-only

# Custom K8s target
cwsandbox tower create-join-token --tower-id=my-tower --namespace=sandbox-system --secret-name=my-token
```

## Test plan

- [ ] Verify `cwsandbox tower create-join-token --help` displays all options
- [ ] Test `--generate-only` against a running ATC instance
- [ ] Test K8s secret creation with `--kubeconfig` pointing to a target cluster
- [ ] Test `--json` with inline payload and stdin pipe
- [ ] Test flag precedence over JSON values
- [ ] Verify error handling for missing `--api-key`, missing `--tower-id`, bad server, invalid JSON

Closes #69