### PR TITLE
feat: Add tags and container_image to Sandbox

### DIFF
--- a/src/cwsandbox/_sandbox.py
+++ b/src/cwsandbox/_sandbox.py
@@ -482,7 +482,9 @@ class Sandbox:
             args: Optional arguments for the command
             defaults: Optional SandboxDefaults to apply
             container_image: Container image to use (default: python:3.11)
-            tags: Optional tags for the sandbox
+            tags: Optional tags for the sandbox. Tags must contain only
+                alphanumeric characters, ``-``, ``_``, or ``.``, and must
+                start and end with an alphanumeric character (max 63 chars).
             base_url: API URL (default: CWSANDBOX_BASE_URL env or localhost)
             request_timeout_seconds: Timeout for API requests (client-side, default: 300s)
             max_lifetime_seconds: Max sandbox lifetime (server-side). If not set,
@@ -536,7 +538,7 @@ class Sandbox:
             else self._defaults.max_lifetime_seconds
         )
 
-        self._tags: list[str] | None = self._defaults.merge_tags(tags)
+        self._tags: list[str] = self._defaults.merge_tags(tags)
         self._environment_variables = self._defaults.merge_environment_variables(
             environment_variables
         )
@@ -676,7 +678,9 @@ class Sandbox:
             defaults: Optional SandboxDefaults to apply
             request_timeout_seconds: Timeout for API requests (client-side)
             max_lifetime_seconds: Max sandbox lifetime (server-side)
-            tags: Optional tags for the sandbox
+            tags: Optional tags for the sandbox. Tags must contain only
+                alphanumeric characters, ``-``, ``_``, or ``.``, and must
+                start and end with an alphanumeric character (max 63 chars).
             profile_ids: Optional list of profile IDs
             runner_ids: Optional list of runner IDs
             resources: Resource configuration. Accepts ResourceOptions for separate
@@ -801,8 +805,8 @@ class Sandbox:
         # Not applicable for discovered sandboxes
         sandbox._command = None
         sandbox._args = None
-        sandbox._container_image = None
-        sandbox._tags = None
+        sandbox._container_image = getattr(info, "container_image", None) or None
+        sandbox._tags = list(getattr(info, "tags", None) or [])
         sandbox._max_lifetime_seconds = None
         sandbox._profile_ids = None
         sandbox._runner_ids = None
@@ -1242,6 +1246,19 @@ class Sandbox:
         return None
 
     @property
+    def tags(self) -> tuple[str, ...]:
+        """Tags associated with this sandbox.
+
+        Returns an empty tuple when the sandbox has no tags.
+        """
+        return tuple(self._tags)
+
+    @property
+    def container_image(self) -> str | None:
+        """Container image used by this sandbox, or None if unknown."""
+        return self._container_image
+
+    @property
     def service_address(self) -> str | None:
         """External address for accessing sandbox services.
 
@@ -1369,6 +1386,7 @@ class Sandbox:
 
         Returns:
             The new _LifecycleState (does NOT mutate self._state).
+            Side effect: updates self._tags from the response.
         """
         if isinstance(self._state, _Terminal):
             return self._state
@@ -1405,6 +1423,11 @@ class Sandbox:
             returncode = info.returncode
         else:
             returncode = None
+
+        self._tags = list(getattr(info, "tags", None) or [])
+        container_image = getattr(info, "container_image", None)
+        if container_image:
+            self._container_image = container_image
 
         new_state = _lifecycle_state_from_info(
             sandbox_id=sandbox_id,
@@ -1779,7 +1802,7 @@ class Sandbox:
                 "command": self._command,
                 "args": self._args or [],
                 "container_image": self._container_image,
-                "tags": self._tags or [],
+                "tags": self._tags,
             }
 
             if self._max_lifetime_seconds is not None:
@@ -1879,6 +1902,7 @@ class Sandbox:
             )
             self._applied_ingress_mode = response.applied_ingress_mode or None
             self._applied_egress_mode = response.applied_egress_mode or None
+            self._tags = list(getattr(response, "tags", None) or [])
 
             # Extract resource limits/requests echoed back from the start response
             if response.HasField("requested_resource_limits"):

--- a/src/cwsandbox/cli/list.py
+++ b/src/cwsandbox/cli/list.py
@@ -35,8 +35,8 @@ _STATUS_CHOICES = [s.value for s in SandboxStatus if s != SandboxStatus.UNSPECIF
     "-o",
     "output_format",
     default="table",
-    type=click.Choice(["table", "json"], case_sensitive=False),
-    help="Output format.",
+    type=click.Choice(["table", "wide", "json"], case_sensitive=False),
+    help="Output format (table, wide, json).",
 )
 def list_sandboxes(
     status: str | None,
@@ -47,7 +47,8 @@ def list_sandboxes(
 ) -> None:
     """List sandboxes.
 
-    Displays sandbox ID, status, runner, profile, and started time for matching sandboxes.
+    Default table shows ID, status, image, and started time. Use -o wide
+    for runner, runner group, profile, and tags. Use -o json for all fields.
     """
     sandboxes = Sandbox.list(
         tags=list(tags) if tags else None,
@@ -65,6 +66,8 @@ def list_sandboxes(
                 "profile_id": sb.profile_id,
                 "runner_group_id": sb.runner_group_id,
                 "started_at": sb.started_at.isoformat() if sb.started_at else None,
+                "container_image": sb.container_image,
+                "tags": list(sb.tags) if sb.tags else [],
             }
             for sb in sandboxes
         ]
@@ -75,13 +78,26 @@ def list_sandboxes(
         click.echo("No sandboxes found.")
         return
 
-    click.echo(f"{'SANDBOX ID':<40} {'STATUS':<14} {'TOWER':<20} {'RUNWAY':<20} {'STARTED AT'}")
-    click.echo(f"{'-' * 40} {'-' * 14} {'-' * 20} {'-' * 20} {'-' * 24}")
+    wide = output_format == "wide"
+
+    header = f"{'SANDBOX ID':<40} {'STATUS':<14} {'IMAGE':<25} {'STARTED AT':<24}"
+    sep = f"{'-' * 40} {'-' * 14} {'-' * 25} {'-' * 24}"
+    if wide:
+        header += f" {'RUNNER':<20} {'RUNNER GROUP':<20} {'PROFILE':<20} {'TAGS'}"
+        sep += f" {'-' * 20} {'-' * 20} {'-' * 20} {'-' * 40}"
+    click.echo(header)
+    click.echo(sep)
 
     for sb in sandboxes:
         sid = sb.sandbox_id or "-"
         st = sb.status.value if sb.status else "-"
-        runner = sb.runner_id or "-"
-        profile = sb.profile_id or "-"
+        image = sb.container_image or "-"
         started = sb.started_at.strftime("%Y-%m-%d %H:%M:%S UTC") if sb.started_at else "-"
-        click.echo(f"{sid:<40} {st:<14} {runner:<20} {profile:<20} {started}")
+        line = f"{sid:<40} {st:<14} {image:<25} {started:<24}"
+        if wide:
+            runner = sb.runner_id or "-"
+            runner_group = sb.runner_group_id or "-"
+            profile = sb.profile_id or "-"
+            tags_str = ",".join(sb.tags) if sb.tags else "-"
+            line += f" {runner:<20} {runner_group:<20} {profile:<20} {tags_str}"
+        click.echo(line)

--- a/tests/integration/cwsandbox/test_sandbox.py
+++ b/tests/integration/cwsandbox/test_sandbox.py
@@ -1209,18 +1209,21 @@ def test_sandbox_list_include_stopped(sandbox_defaults: SandboxDefaults) -> None
     # With include_stopped=True, the sandbox should appear.
     # The status may not yet reflect the final terminal state, so we only
     # assert the sandbox is returned — not a specific status.
-    found = False
+    matched_sb = None
     for _ in range(15):
         sandboxes = Sandbox.list(tags=[unique_tag], include_stopped=True).result()
         for sb in sandboxes:
             if sb.sandbox_id == sandbox_id:
-                found = True
+                matched_sb = sb
                 break
-        if found:
+        if matched_sb:
             break
         time.sleep(1)
 
-    assert found, f"Stopped sandbox {sandbox_id} not found with include_stopped=True"
+    assert matched_sb is not None, (
+        f"Stopped sandbox {sandbox_id} not found with include_stopped=True"
+    )
+    assert matched_sb.container_image == sandbox_defaults.container_image
 
 
 def test_sandbox_list_terminal_status_filter(sandbox_defaults: SandboxDefaults) -> None:
@@ -1359,3 +1362,97 @@ def test_default_command_produces_no_logs(sandbox_defaults: SandboxDefaults) -> 
             sandbox.stop(missing_ok=True).result()
         except SandboxError:
             pass
+
+
+# Tag tests
+
+
+def test_sandbox_tags_from_id(sandbox_defaults: SandboxDefaults) -> None:
+    """Tags set at creation are recovered via from_id."""
+    unique = uuid.uuid4().hex[:8]
+    custom_tags = [f"tag-a-{unique}", f"tag-b-{unique}"]
+
+    with Sandbox.run(
+        "sleep", "infinity", defaults=sandbox_defaults, tags=custom_tags
+    ) as sandbox:
+        sandbox.wait()
+
+        recovered = Sandbox.from_id(sandbox.sandbox_id).result()
+
+        # Tags from defaults (integration-test, session tag) plus custom tags
+        for tag in custom_tags:
+            assert tag in recovered.tags
+
+
+def test_sandbox_tags_list_filter(sandbox_defaults: SandboxDefaults) -> None:
+    """Sandbox.list filters by tags with AND semantics."""
+    unique = uuid.uuid4().hex[:8]
+    shared_tag = f"shared-{unique}"
+    only_a_tag = f"only-a-{unique}"
+    only_b_tag = f"only-b-{unique}"
+
+    # Create sequentially to avoid resource pressure on local clusters
+    with Sandbox.run(
+        "sleep", "infinity", defaults=sandbox_defaults, tags=[shared_tag, only_a_tag]
+    ) as sb_a:
+        sb_a.wait()
+
+        with Sandbox.run(
+            "sleep", "infinity", defaults=sandbox_defaults, tags=[shared_tag, only_b_tag]
+        ) as sb_b:
+            sb_b.wait()
+
+            # Filter by shared tag — both should appear
+            shared_results = Sandbox.list(tags=[shared_tag]).result()
+            shared_ids = {s.sandbox_id for s in shared_results}
+            assert sb_a.sandbox_id in shared_ids
+            assert sb_b.sandbox_id in shared_ids
+
+            # Filter by only_a — only sb_a should appear
+            a_results = Sandbox.list(tags=[only_a_tag]).result()
+            a_ids = {s.sandbox_id for s in a_results}
+            assert sb_a.sandbox_id in a_ids
+            assert sb_b.sandbox_id not in a_ids
+
+            # AND semantics — filter by both shared + only_a
+            and_results = Sandbox.list(tags=[shared_tag, only_a_tag]).result()
+            and_ids = {s.sandbox_id for s in and_results}
+            assert sb_a.sandbox_id in and_ids
+            assert sb_b.sandbox_id not in and_ids
+
+
+def test_sandbox_tags_rejects_invalid(sandbox_defaults: SandboxDefaults) -> None:
+    """Tags with invalid characters are rejected by the server."""
+    from cwsandbox.exceptions import SandboxError
+
+    # Tags with spaces are invalid K8s label name segments
+    with pytest.raises(SandboxError, match="(?i)invalid|label"):
+        sandbox = Sandbox.run(
+            "sleep", "infinity", defaults=sandbox_defaults, tags=["has space"]
+        )
+        sandbox.wait()
+
+
+def test_sandbox_tags_rejects_too_long(sandbox_defaults: SandboxDefaults) -> None:
+    """Tags exceeding K8s label length limit are rejected."""
+    from cwsandbox.exceptions import SandboxError
+
+    # K8s label name segment max is 63 chars; prefix eats 24, so tag > 39 chars overflows
+    long_tag = "a" * 64
+    with pytest.raises(SandboxError, match="(?i)invalid|63 bytes|label"):
+        sandbox = Sandbox.run(
+            "sleep", "infinity", defaults=sandbox_defaults, tags=[long_tag]
+        )
+        sandbox.wait()
+
+
+# Container image tests
+
+
+def test_sandbox_container_image_from_id(sandbox_defaults: SandboxDefaults) -> None:
+    """Container image is returned via from_id."""
+    with Sandbox.run("sleep", "infinity", defaults=sandbox_defaults) as sandbox:
+        sandbox.wait()
+
+        recovered = Sandbox.from_id(sandbox.sandbox_id).result()
+        assert recovered.container_image == sandbox_defaults.container_image

--- a/tests/unit/cwsandbox/test_cli_list.py
+++ b/tests/unit/cwsandbox/test_cli_list.py
@@ -33,6 +33,8 @@ class TestListCommand:
         mock_sb.status.value = "running"
         mock_sb.runner_id = "tower-1"
         mock_sb.profile_id = "runway-1"
+        mock_sb.container_image = "python:3.11"
+        mock_sb.tags = ("dev", "test")
         mock_sb.started_at = datetime(2026, 1, 15, 10, 30, 0, tzinfo=UTC)
 
         mock_op_ref = MagicMock()
@@ -47,9 +49,12 @@ class TestListCommand:
         assert result.exit_code == 0
         assert "abc-123" in result.output
         assert "running" in result.output
-        assert "tower-1" in result.output
-        assert "runway-1" in result.output
+        assert "python:3.11" in result.output
+        assert "IMAGE" in result.output
         assert "2026-01-15" in result.output
+        # Basic table does not show tower, runway, or tags
+        assert "TOWER" not in result.output
+        assert "TAGS" not in result.output
 
     def test_list_empty(self) -> None:
         """cwsandbox ls shows message when no sandboxes found."""
@@ -101,6 +106,8 @@ class TestListCommand:
         mock_sb.runner_id = "tower-1"
         mock_sb.profile_id = "runway-1"
         mock_sb.runner_group_id = "tg-1"
+        mock_sb.tags = ("dev", "test")
+        mock_sb.container_image = "python:3.11"
         mock_sb.started_at = datetime(2026, 1, 15, 10, 30, 0, tzinfo=UTC)
 
         mock_op_ref = MagicMock()
@@ -122,6 +129,8 @@ class TestListCommand:
                     "profile_id": "runway-1",
                     "runner_group_id": "tg-1",
                     "started_at": "2026-01-15T10:30:00+00:00",
+                    "container_image": "python:3.11",
+                    "tags": ["dev", "test"],
                 }
             ],
             indent=2,
@@ -141,6 +150,74 @@ class TestListCommand:
 
         assert result.exit_code == 0
         assert result.output.strip() == "[]"
+
+    def test_list_json_no_tags(self) -> None:
+        """cwsandbox ls --output json emits empty list for sandbox with no tags."""
+        mock_sb = MagicMock()
+        mock_sb.sandbox_id = "abc-123"
+        mock_sb.status.value = "running"
+        mock_sb.runner_id = "tower-1"
+        mock_sb.profile_id = "runway-1"
+        mock_sb.runner_group_id = "tg-1"
+        mock_sb.tags = None
+        mock_sb.container_image = None
+        mock_sb.started_at = None
+
+        mock_op_ref = MagicMock()
+        mock_op_ref.result.return_value = [mock_sb]
+
+        with patch("cwsandbox.cli.list.Sandbox") as mock_sandbox_cls:
+            mock_sandbox_cls.list.return_value = mock_op_ref
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ["ls", "--output", "json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data[0]["tags"] == []
+        assert data[0]["container_image"] is None
+
+    def test_list_wide_output(self) -> None:
+        """cwsandbox ls -o wide adds RUNNER, RUNNER GROUP, PROFILE, TAGS columns."""
+        sb_with_tags = MagicMock()
+        sb_with_tags.sandbox_id = "abc-123"
+        sb_with_tags.status.value = "running"
+        sb_with_tags.runner_id = "runner-1"
+        sb_with_tags.runner_group_id = "rg-1"
+        sb_with_tags.profile_id = "profile-1"
+        sb_with_tags.container_image = "python:3.11"
+        sb_with_tags.tags = ("gpu", "dev")
+        sb_with_tags.started_at = datetime(2026, 1, 15, 10, 30, 0, tzinfo=UTC)
+
+        sb_no_tags = MagicMock()
+        sb_no_tags.sandbox_id = "def-456"
+        sb_no_tags.status.value = "running"
+        sb_no_tags.runner_id = "runner-1"
+        sb_no_tags.runner_group_id = None
+        sb_no_tags.profile_id = "profile-1"
+        sb_no_tags.container_image = "python:3.11"
+        sb_no_tags.tags = ()
+        sb_no_tags.started_at = None
+
+        mock_op_ref = MagicMock()
+        mock_op_ref.result.return_value = [sb_with_tags, sb_no_tags]
+
+        with patch("cwsandbox.cli.list.Sandbox") as mock_sandbox_cls:
+            mock_sandbox_cls.list.return_value = mock_op_ref
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ["ls", "-o", "wide"])
+
+        assert result.exit_code == 0
+        assert "RUNNER" in result.output
+        assert "RUNNER GROUP" in result.output
+        assert "PROFILE" in result.output
+        assert "TAGS" in result.output
+        assert "gpu,dev" in result.output
+        # Sandbox with no tags shows "-"
+        lines = result.output.strip().split("\n")
+        no_tag_line = [line for line in lines if "def-456" in line][0]
+        assert no_tag_line.rstrip().endswith("-")
 
     def test_list_api_error(self) -> None:
         """cwsandbox ls shows clean error for CWSandboxError from API failure."""

--- a/tests/unit/cwsandbox/test_lifecycle.py
+++ b/tests/unit/cwsandbox/test_lifecycle.py
@@ -51,6 +51,7 @@ def _make_proto_info(
         runner_group_id=runner_group_id,
         started_at_time=started_at_time,
         returncode=returncode,
+        tags=[],
     )
 
 

--- a/tests/unit/cwsandbox/test_sandbox.py
+++ b/tests/unit/cwsandbox/test_sandbox.py
@@ -5357,3 +5357,102 @@ class TestStoppingDel:
 
         with pytest.warns(ResourceWarning, match="was not stopped"):
             sandbox.__del__()
+
+
+class TestSandboxTags:
+    """Tests for the Sandbox.tags property and tags parsing from proto."""
+
+    def test_tags_property_returns_tuple(self) -> None:
+        """Sandbox.tags returns a tuple when tags are set."""
+        sandbox = Sandbox(command="sleep", args=["infinity"], tags=["a", "b"])
+        assert sandbox.tags == ("a", "b")
+
+    def test_tags_property_returns_empty_tuple_when_no_tags(self) -> None:
+        """Sandbox.tags returns empty tuple when no tags are provided."""
+        sandbox = Sandbox(command="sleep", args=["infinity"])
+        assert sandbox.tags == ()
+
+    def test_from_sandbox_info_parses_tags(self) -> None:
+        """_from_sandbox_info populates tags from proto response."""
+        from unittest.mock import MagicMock
+
+        from google.protobuf import timestamp_pb2
+
+        from cwsandbox._proto import gateway_pb2
+
+        info = MagicMock()
+        info.sandbox_id = "test-123"
+        info.sandbox_status = gateway_pb2.SANDBOX_STATUS_RUNNING
+        info.started_at_time = timestamp_pb2.Timestamp(seconds=1234567890)
+        info.runner_id = "runner-1"
+        info.runner_group_id = "group-1"
+        info.profile_id = "profile-1"
+        info.tags = ["tag-a", "tag-b"]
+        sandbox = Sandbox._from_sandbox_info(
+            info,
+            base_url="https://api.example.com",
+            timeout_seconds=300.0,
+        )
+        assert sandbox.tags == ("tag-a", "tag-b")
+
+    def test_from_sandbox_info_empty_tags(self) -> None:
+        """_from_sandbox_info returns empty tuple when proto has empty tags list."""
+        from unittest.mock import MagicMock
+
+        from google.protobuf import timestamp_pb2
+
+        from cwsandbox._proto import gateway_pb2
+
+        info = MagicMock()
+        info.sandbox_id = "test-123"
+        info.sandbox_status = gateway_pb2.SANDBOX_STATUS_RUNNING
+        info.started_at_time = timestamp_pb2.Timestamp(seconds=1234567890)
+        info.runner_id = "runner-1"
+        info.runner_group_id = "group-1"
+        info.profile_id = "profile-1"
+        info.tags = []
+        sandbox = Sandbox._from_sandbox_info(
+            info,
+            base_url="https://api.example.com",
+            timeout_seconds=300.0,
+        )
+        assert sandbox.tags == ()
+
+    def test_apply_sandbox_info_updates_tags_when_proto_has_field(self) -> None:
+        """_apply_sandbox_info updates _tags when proto response has tags field (even if empty)."""
+        from unittest.mock import MagicMock
+
+        from google.protobuf import timestamp_pb2
+
+        from cwsandbox._proto import gateway_pb2
+
+        # Create a sandbox with existing tags
+        info = MagicMock()
+        info.sandbox_id = "test-123"
+        info.sandbox_status = gateway_pb2.SANDBOX_STATUS_RUNNING
+        info.started_at_time = timestamp_pb2.Timestamp(seconds=1234567890)
+        info.runner_id = "runner-1"
+        info.runner_group_id = "group-1"
+        info.profile_id = "profile-1"
+        info.tags = ["old-tag"]
+        sandbox = Sandbox._from_sandbox_info(
+            info,
+            base_url="https://api.example.com",
+            timeout_seconds=300.0,
+        )
+        assert sandbox.tags == ("old-tag",)
+
+        # Poll response with empty tags list (field present but empty)
+        update_info = MagicMock()
+        update_info.sandbox_id = "test-123"
+        update_info.sandbox_status = gateway_pb2.SANDBOX_STATUS_RUNNING
+        update_info.started_at_time = timestamp_pb2.Timestamp(seconds=1234567890)
+        update_info.runner_id = "runner-1"
+        update_info.runner_group_id = "group-1"
+        update_info.profile_id = "profile-1"
+        update_info.tags = []
+
+        sandbox._apply_sandbox_info(update_info, source="poll")
+
+        # Tags should be updated to empty tuple
+        assert sandbox.tags == ()


### PR DESCRIPTION
Expose Sandbox.tags and Sandbox.container_image properties from
Start/Get/List responses. Refactor cwsandbox ls into table/wide/json
output modes: default shows ID, status, image, started_at; wide adds
tower, tower group, runway, tags.

```
cwsandbox ls        
SANDBOX ID                               STATUS         IMAGE                     STARTED AT              
---------------------------------------- -------------- ------------------------- ------------------------
17bcd812-c1ee-43db-a9ee-4f6f98503847     running        python:3.11               2026-04-01 15:49:39 UTC 

cwsandbox ls -o wide
SANDBOX ID                               STATUS         IMAGE                     STARTED AT               TOWER                TOWER GROUP          RUNWAY               TAGS
---------------------------------------- -------------- ------------------------- ------------------------ -------------------- -------------------- -------------------- ----------------------------------------
17bcd812-c1ee-43db-a9ee-4f6f98503847     running        python:3.11               2026-04-01 15:49:39 UTC  dev-1                -                    default              interactive,streaming

cwsandbox ls -o json
[
  {
    "sandbox_id": "17bcd812-c1ee-43db-a9ee-4f6f98503847",
    "status": "running",
    "tower_id": "dev-1",
    "runway_id": "default",
    "tower_group_id": null,
    "started_at": "2026-04-01T15:49:39.237815",
    "container_image": "python:3.11",
    "tags": [
      "interactive",
      "streaming"
    ]
  }
]
```

Closes #65