### PR TITLE
fix: enforce keyword args on NetworkOptions and Secret

### DIFF
--- a/src/cwsandbox/_types.py
+++ b/src/cwsandbox/_types.py
@@ -123,7 +123,7 @@ class ExecOutcome(StrEnum):
     FAILURE = "failure"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class NetworkOptions:
     """Network configuration for sandbox ingress/egress.
 
@@ -149,7 +149,7 @@ class NetworkOptions:
             object.__setattr__(self, "exposed_ports", None)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class Secret:
     """A secret to inject from a store into a sandbox environment variable.
 


### PR DESCRIPTION
Split from: https://github.com/coreweave/cwsandbox-client/pull/78

Keep the API unambiguous by enforcing keyword arguments, making positional construction not possible. This is already enforced at the type checking level so no changes needed in our code, tests or examples. For users of the SDK, this prevents them from accidentally defining the wrong field when there are multiple optional fields. For example, with `Secret`, the `field` and `env_var` fields are both optional, with `field` coming before `env_var`. However, a user wanting to assign an environment variable without using the `field` field could accidentally write `Secret("wandb", "foo", "FOO")` which will assign `"FOO"` to `field`