### PR TITLE
feat(tests): pin e2e sandboxes to specific runner(s)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,10 @@
 # Optional: API Endpoint Override
 # =============================================================================
 # CWSANDBOX_BASE_URL=https://api.cwsandbox.com
+
+# =============================================================================
+# Optional: Pin e2e sandboxes to specific runner(s)
+# =============================================================================
+# Comma-separated list. Overridden by `--cwsandbox-runner-ids=<csv>` on the
+# pytest command line; pass the flag with an empty value to auto-schedule.
+# CWSANDBOX_TEST_RUNNER_IDS=runner-a,runner-b

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -13,9 +13,11 @@ tests/
 ├── unit/cwsandbox/        # Mock-based tests, no network calls (284 tests)
 │   ├── conftest.py     # Auth env var clearing (autouse=True)
 │   └── test_*.py       # 10 test files (one per source module + utilities)
-└── integration/cwsandbox/ # Real backend operations (31 tests)
-    ├── conftest.py     # Shared fixtures
-    └── test_*.py       # 3 test files (auth, sandbox, session)
+└── integration/           # Real backend operations (31 tests)
+    ├── conftest.py     # Integration-root CLI options (e.g., --cwsandbox-runner-ids)
+    └── cwsandbox/
+        ├── conftest.py # Shared fixtures (auth, sandbox_defaults, runner-ID resolution)
+        └── test_*.py   # 3 test files (auth, sandbox, session)
 ```
 
 ## Running Tests
@@ -46,7 +48,14 @@ uv run pytest -k "test_create"                   # By name pattern
 | Fixture | Scope | Autouse | Description |
 |---------|-------|---------|-------------|
 | `require_auth` | module | Yes | Skips tests if no auth configured |
-| `sandbox_defaults` | module | No | Returns `SandboxDefaults` with `python:3.11`, 300s lifetime, `("integration-test",)` tags |
+| `_validate_runner_ids` | session | Yes | Fails fast (pytest.UsageError) when `--cwsandbox-runner-ids` or `CWSANDBOX_TEST_RUNNER_IDS` names a runner the discovery service does not know. Zero-cost when no runner targeting is configured. |
+| `sandbox_defaults` | module | No | Returns `SandboxDefaults` with `python:3.11`, 60s lifetime, `("integration-test", <session-tag>)` tags. Populates `runner_ids` from `--cwsandbox-runner-ids` (CLI) or `CWSANDBOX_TEST_RUNNER_IDS` (env) when set. |
+
+### Integration CLI flags (`tests/integration/conftest.py`)
+
+| Flag | Env var | Description |
+|------|---------|-------------|
+| `--cwsandbox-runner-ids=<csv>` | `CWSANDBOX_TEST_RUNNER_IDS` | Comma-separated runner IDs to pin e2e sandboxes to. CLI wins over env. Pass empty (`--cwsandbox-runner-ids=`) to clear the env and auto-schedule. |
 
 Set environment variables before running integration tests. A `.env` file in the project root is automatically loaded via python-dotenv.
 
@@ -88,6 +97,30 @@ Set environment variables before running tests (in priority order):
 A `.env` file in the project root is automatically loaded via python-dotenv.
 
 Tests skip gracefully with clear messages when no auth is configured. The `require_auth` fixture in conftest.py validates auth upfront rather than letting tests fail with opaque RPC errors.
+
+### Targeting specific runners
+
+When rolling out a change to a specific runner, pin every e2e sandbox to that runner rather than letting the backend auto-schedule. The `sandbox_defaults` fixture reads the target list from either the pytest CLI flag or an env var; the CLI flag wins when both are set.
+
+```bash
+# CLI: pin to one runner for a single test
+mise run test:e2e -- --cwsandbox-runner-ids=runner-a
+
+# CLI: pin to a set
+mise run test:e2e -- --cwsandbox-runner-ids=runner-a,runner-b
+
+# Env: convenient when iterating in a shell
+CWSANDBOX_TEST_RUNNER_IDS=runner-a mise run test:e2e
+
+# Clear the env for one invocation (auto-schedule)
+CWSANDBOX_TEST_RUNNER_IDS=runner-a mise run test:e2e -- --cwsandbox-runner-ids=
+```
+
+Parsing normalises the list: whitespace is stripped, empty tokens are dropped, and duplicates are collapsed preserving first-seen order. If any resolved ID is unknown to the discovery service, pytest stops immediately with `pytest.UsageError` naming the missing IDs and their source (CLI vs env). When no targeting is configured, no discovery call is made - the default path is byte-identical to pre-change.
+
+Scope: this constrains runner placement only. Profile selection remains backend-driven; `container_image`, `resources`, `tags`, `max_lifetime_seconds` are unchanged.
+
+xdist caveat: every xdist worker targets the same runner tuple. When pinning to a single runner, lower `-n` (or run sequential with `mise run test:e2e`) to avoid queueing all workers behind one node.
 
 ## Test File Reference
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: cwsandbox-client
+
+"""Root conftest for integration tests.
+
+Registers integration-wide command-line options. Defined at this level (not
+inside ``cwsandbox/``) so pytest picks them up when collecting any subtree of
+``tests/integration/``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Register CWSandbox integration test options.
+
+    The default for ``--cwsandbox-runner-ids`` is ``None`` (the sentinel for
+    "flag not passed"), which is distinct from ``""`` ("flag passed empty,
+    clear the env var").
+    """
+    group = parser.getgroup("cwsandbox", "CWSandbox integration tests")
+    group.addoption(
+        "--cwsandbox-runner-ids",
+        action="store",
+        default=None,
+        metavar="RUNNER_IDS",
+        help=(
+            "Comma-separated runner IDs to pin e2e sandboxes to. Overrides "
+            "CWSANDBOX_TEST_RUNNER_IDS. Pass empty (--cwsandbox-runner-ids=) "
+            "to clear the env var and auto-schedule."
+        ),
+    )

--- a/tests/integration/cwsandbox/conftest.py
+++ b/tests/integration/cwsandbox/conftest.py
@@ -20,12 +20,90 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from cwsandbox import Sandbox, SandboxDefaults
+from cwsandbox import Sandbox, SandboxDefaults, list_runners
 from cwsandbox._auth import resolve_auth
 from cwsandbox.exceptions import CWSandboxError
 
 if TYPE_CHECKING:
     pass
+
+
+_ENV_RUNNER_IDS = "CWSANDBOX_TEST_RUNNER_IDS"
+_CLI_RUNNER_IDS = "--cwsandbox-runner-ids"
+
+
+def _parse_runner_ids(raw: str) -> tuple[str, ...] | None:
+    """Parse a comma-separated runner ID string.
+
+    Contract: split on ``,``, strip whitespace, drop empty tokens, dedupe
+    preserving first-seen order. Returns ``None`` if nothing remains.
+    """
+    seen: set[str] = set()
+    result: list[str] = []
+    for token in raw.split(","):
+        trimmed = token.strip()
+        if not trimmed or trimmed in seen:
+            continue
+        seen.add(trimmed)
+        result.append(trimmed)
+    return tuple(result) if result else None
+
+
+def _resolve_runner_ids(
+    cli_value: str | None, env_value: str | None
+) -> tuple[tuple[str, ...] | None, str | None]:
+    """Resolve configured runner IDs. CLI wins; empty CLI clears env.
+
+    ``cli_value`` is ``None`` when the flag was not passed, ``""`` when
+    passed explicitly empty (clears), or a string value. Returns
+    ``(runner_ids, source_label)`` where ``source_label`` is ``None`` when
+    ``runner_ids`` is ``None``.
+    """
+    if cli_value is not None:
+        ids = _parse_runner_ids(cli_value)
+        source = f"CLI ({_CLI_RUNNER_IDS})" if ids is not None else None
+        return ids, source
+    if env_value is not None:
+        ids = _parse_runner_ids(env_value)
+        source = f"env ({_ENV_RUNNER_IDS})" if ids is not None else None
+        return ids, source
+    return None, None
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _validate_runner_ids(pytestconfig: pytest.Config) -> None:
+    """Fail fast when configured runner IDs are unknown.
+
+    Only performs a discovery call when ``runner_ids`` resolves to a
+    non-empty tuple; the default path (no flag, no env) is zero-cost. Also
+    skips validation when no auth is configured, since ``require_auth``
+    will skip the tests anyway.
+    """
+    cli_value = pytestconfig.getoption(_CLI_RUNNER_IDS)
+    env_value = os.environ.get(_ENV_RUNNER_IDS)
+    runner_ids, source_label = _resolve_runner_ids(cli_value, env_value)
+
+    if runner_ids is None:
+        return
+
+    if resolve_auth().strategy == "none":
+        return
+
+    try:
+        runners = list_runners()
+    except CWSandboxError as exc:
+        raise pytest.UsageError(
+            f"Failed to verify runner IDs via discovery service: {exc}"
+        ) from exc
+
+    known_ids = {r.runner_id for r in runners}
+    missing = [rid for rid in runner_ids if rid not in known_ids]
+    if missing:
+        available = ", ".join(sorted(known_ids)) if known_ids else "(none)"
+        raise pytest.UsageError(
+            f"Unknown runner ID(s) from {source_label}: {', '.join(missing)}. "
+            f"Available runner IDs: {available}"
+        )
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -93,7 +171,7 @@ def cleanup_session_sandboxes() -> Generator[None, None, None]:
 
 
 @pytest.fixture(scope="module")
-def sandbox_defaults() -> SandboxDefaults:
+def sandbox_defaults(request: pytest.FixtureRequest) -> SandboxDefaults:
     """Module-scoped defaults for creating test sandboxes.
 
     Uses reduced resources and short lifetime for local Kind cluster
@@ -102,10 +180,16 @@ def sandbox_defaults() -> SandboxDefaults:
     Includes a unique session tag to identify sandboxes from this test run,
     enabling cleanup of orphaned sandboxes at session end.
 
-    Respects CWSANDBOX_BASE_URL environment variable for testing against
-    local backends (e.g., Tilt/Kind development setup).
+    Respects ``CWSANDBOX_BASE_URL`` for pointing at local backends (e.g.,
+    Tilt/Kind). Respects ``CWSANDBOX_TEST_RUNNER_IDS`` or
+    ``--cwsandbox-runner-ids`` to pin sandboxes to specific runner(s) --
+    CLI wins, empty CLI clears the env var. Only ``runner_ids`` is touched
+    by this targeting; all other defaults are unchanged.
     """
     base_url = os.environ.get("CWSANDBOX_BASE_URL")
+    cli_value = request.config.getoption(_CLI_RUNNER_IDS)
+    env_value = os.environ.get(_ENV_RUNNER_IDS)
+    runner_ids, _ = _resolve_runner_ids(cli_value, env_value)
 
     # Build kwargs, only including base_url if explicitly set
     kwargs: dict[str, object] = {
@@ -116,5 +200,7 @@ def sandbox_defaults() -> SandboxDefaults:
     }
     if base_url:
         kwargs["base_url"] = base_url
+    if runner_ids is not None:
+        kwargs["runner_ids"] = runner_ids
 
     return SandboxDefaults(**kwargs)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Engineers rolling out a runner-side change need to verify the rollout against only the affected runner(s). Before this, the e2e `sandbox_defaults` fixture left `runner_ids=None` and every sandbox was auto-scheduled by the backend, forcing ad-hoc `conftest.py` edits to target a specific runner.

This adds a pytest CLI flag `--cwsandbox-runner-ids=<csv>` and an env var `CWSANDBOX_TEST_RUNNER_IDS` that feed into `sandbox_defaults.runner_ids`. A session-scoped autouse fixture validates configured IDs against the discovery service so unknown IDs surface as `pytest.UsageError` before a sandbox is ever created.

## Design Decisions

**CLI flag wins over env var; empty CLI explicitly clears the env.** Shell-level env vars are convenient when iterating but sticky across invocations. Giving `--cwsandbox-runner-ids=<csv>` priority lets engineers override a stale env var for a single run, and `--cwsandbox-runner-ids=` (empty) is the one-off "auto-schedule anyway" escape hatch.

**Two conftests, not one.** Pytest's default integration invocation is `pytest tests/integration/`, so `pytest_addoption` must live at or above that collection root - otherwise `pytest tests/integration/ --help` would not show the flag and the flag would error as unknown. The new `tests/integration/conftest.py` is therefore CLI-option-only; all parsing, resolution, validation, and `sandbox_defaults` consumption lives in `tests/integration/cwsandbox/conftest.py` where it is used.

**Fail fast on unknown runner IDs.** When targeting is configured, a session-scoped autouse fixture calls `list_runners()` once and raises `pytest.UsageError` if any configured ID is unknown, naming the missing IDs and the source (CLI vs env). This prevents a typo from surfacing as an opaque backend error several minutes into the test run. The validation is gated on `runner_ids is not None`, so the no-targeting default path makes no discovery call - byte-identical to pre-change behavior.

**Scope bound to `runner_ids` only.** `container_image`, `resources`, `tags`, and `max_lifetime_seconds` are left alone. Profile selection remains backend-driven. Narrowing scope keeps the flag composable with whatever defaults the fixture builds today and avoids relitigating those defaults here.

**Parsing contract: split on `,`, strip, drop empties, dedupe preserving first-seen order.** Documented explicitly so behavior is predictable across shell quoting quirks. A whitespace-only or all-commas value is treated as unset (no validation call, no `runner_ids` in defaults).

## Review

Reviewed by multi-agent team: no actionable findings at Critical or High severity. One Medium finding (missing unit tests for the pure-function helpers) was acknowledged and deferred to a follow-up; the logic is exercised end-to-end via the verification steps below. One Low finding (docs structure block out of sync with the two-conftest layout) was fixed in this PR.

## Testing

- [x] `uv run ruff check .` - PASS
- [x] `uv run ruff format --check .` - PASS
- [x] `uv run mypy src/` - PASS
- [x] `uv run pytest tests/unit/` - PASS (all unit tests)
- [x] `uv run pytest tests/integration/ --help` - new flag shown in grouped section
- [x] Fail-fast validation: `CWSANDBOX_TEST_RUNNER_IDS=bad-id pytest tests/integration/...` raises `pytest.UsageError` with correct source label; empty CLI clears env var.
- [x] Parsing edge cases: `",,,"` treated as unset (no discovery call); `" a , b , a "` normalises to `("a", "b")`.
- [x] Zero-cost default confirmed via tripwire on `list_runners`: discovery is NOT called when neither CLI flag nor env var is set.
- [x] Runner placement confirmed end-to-end: `Sandbox.run(runner_ids=("<target>",))` returns a sandbox whose `runner_id` matches the target; unpinned sandbox auto-schedules to a different runner.
