### PR TITLE
fix(tests): close e2e runner-pin bypass in minimal-defaults tests

### DIFF
--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -49,7 +49,8 @@ uv run pytest -k "test_create"                   # By name pattern
 |---------|-------|---------|-------------|
 | `require_auth` | module | Yes | Skips tests if no auth configured |
 | `_validate_runner_ids` | session | Yes | Fails fast (pytest.UsageError) when `--cwsandbox-runner-ids` or `CWSANDBOX_TEST_RUNNER_IDS` names a runner the discovery service does not know. Zero-cost when no runner targeting is configured. |
-| `sandbox_defaults` | module | No | Returns `SandboxDefaults` with `python:3.11`, 60s lifetime, `("integration-test", <session-tag>)` tags. Populates `runner_ids` from `--cwsandbox-runner-ids` (CLI) or `CWSANDBOX_TEST_RUNNER_IDS` (env) when set. |
+| `configured_runner_ids` | session | No | Returns `tuple[str, ...] \| None` resolved from `--cwsandbox-runner-ids` / `CWSANDBOX_TEST_RUNNER_IDS` (CLI wins). Consume this in tests that construct their own `SandboxDefaults` or call `Sandbox.run()` without defaults, so the runner pin still applies. |
+| `sandbox_defaults` | module | No | Returns `SandboxDefaults` with `python:3.11`, 60s lifetime, `("integration-test", <session-tag>)` tags. Inherits `runner_ids` from `configured_runner_ids` when set. |
 
 ### Integration CLI flags (`tests/integration/conftest.py`)
 
@@ -121,6 +122,15 @@ Parsing normalises the list: whitespace is stripped, empty tokens are dropped, a
 Scope: this constrains runner placement only. Profile selection remains backend-driven; `container_image`, `resources`, `tags`, `max_lifetime_seconds` are unchanged.
 
 xdist caveat: every xdist worker targets the same runner tuple. When pinning to a single runner, lower `-n` (or run sequential with `mise run test:e2e`) to avoid queueing all workers behind one node.
+
+### Contract for new e2e tests
+
+Any test path that may create a sandbox - directly via `Sandbox.run()`, indirectly via `Session`, or via a `@session.function()` - MUST honor the configured runner pin. To comply, either:
+
+1. Consume `sandbox_defaults` (or `sandbox_defaults.with_overrides(...)`) - the pin is inherited automatically, OR
+2. Accept the `configured_runner_ids` fixture and forward it: pass `runner_ids=list(configured_runner_ids)` to `Sandbox.run()` when non-None.
+
+**Opt-out:** tests that are specifically validating `runner_ids` or `profile_ids` semantics (e.g., `test_sandbox_with_runway_and_runner_ids`) may opt out. Document the opt-out with an in-test comment explaining why the pin is not forwarded. Note that an explicit `runner_ids=[]` intentionally clears any default.
 
 ## Test File Reference
 

--- a/tests/integration/cwsandbox/conftest.py
+++ b/tests/integration/cwsandbox/conftest.py
@@ -70,6 +70,22 @@ def _resolve_runner_ids(
     return None, None
 
 
+@pytest.fixture(scope="session")
+def configured_runner_ids(
+    pytestconfig: pytest.Config,
+) -> tuple[str, ...] | None:
+    """Runner IDs resolved from --cwsandbox-runner-ids / CWSANDBOX_TEST_RUNNER_IDS.
+
+    Returns None when no pin is configured. Use this fixture in tests that
+    construct their own SandboxDefaults or call Sandbox.run() without
+    defaults, so the runner pin still applies.
+    """
+    cli_value = pytestconfig.getoption(_CLI_RUNNER_IDS)
+    env_value = os.environ.get(_ENV_RUNNER_IDS)
+    runner_ids, _ = _resolve_runner_ids(cli_value, env_value)
+    return runner_ids
+
+
 @pytest.fixture(scope="session", autouse=True)
 def _validate_runner_ids(pytestconfig: pytest.Config) -> None:
     """Fail fast when configured runner IDs are unknown.
@@ -171,7 +187,9 @@ def cleanup_session_sandboxes() -> Generator[None, None, None]:
 
 
 @pytest.fixture(scope="module")
-def sandbox_defaults(request: pytest.FixtureRequest) -> SandboxDefaults:
+def sandbox_defaults(
+    configured_runner_ids: tuple[str, ...] | None,
+) -> SandboxDefaults:
     """Module-scoped defaults for creating test sandboxes.
 
     Uses reduced resources and short lifetime for local Kind cluster
@@ -181,15 +199,12 @@ def sandbox_defaults(request: pytest.FixtureRequest) -> SandboxDefaults:
     enabling cleanup of orphaned sandboxes at session end.
 
     Respects ``CWSANDBOX_BASE_URL`` for pointing at local backends (e.g.,
-    Tilt/Kind). Respects ``CWSANDBOX_TEST_RUNNER_IDS`` or
-    ``--cwsandbox-runner-ids`` to pin sandboxes to specific runner(s) --
-    CLI wins, empty CLI clears the env var. Only ``runner_ids`` is touched
-    by this targeting; all other defaults are unchanged.
+    Tilt/Kind). Inherits the runner pin from ``configured_runner_ids``
+    (resolved from ``--cwsandbox-runner-ids`` / ``CWSANDBOX_TEST_RUNNER_IDS``).
+    Only ``runner_ids`` is touched by this targeting; all other defaults are
+    unchanged.
     """
     base_url = os.environ.get("CWSANDBOX_BASE_URL")
-    cli_value = request.config.getoption(_CLI_RUNNER_IDS)
-    env_value = os.environ.get(_ENV_RUNNER_IDS)
-    runner_ids, _ = _resolve_runner_ids(cli_value, env_value)
 
     # Build kwargs, only including base_url if explicitly set
     kwargs: dict[str, object] = {
@@ -200,7 +215,7 @@ def sandbox_defaults(request: pytest.FixtureRequest) -> SandboxDefaults:
     }
     if base_url:
         kwargs["base_url"] = base_url
-    if runner_ids is not None:
-        kwargs["runner_ids"] = runner_ids
+    if configured_runner_ids is not None:
+        kwargs["runner_ids"] = configured_runner_ids
 
     return SandboxDefaults(**kwargs)  # type: ignore[arg-type]

--- a/tests/integration/cwsandbox/test_sandbox.py
+++ b/tests/integration/cwsandbox/test_sandbox.py
@@ -38,9 +38,14 @@ def test_sandbox_run_factory(sandbox_defaults: SandboxDefaults) -> None:
         assert sandbox.status == "running"
 
 
-def test_sandbox_run_factory_no_defaults() -> None:
+def test_sandbox_run_factory_no_defaults(
+    configured_runner_ids: tuple[str, ...] | None,
+) -> None:
     """Test Sandbox.run factory method without defaults - exercises default config path."""
-    sandbox = Sandbox.run("echo", "hello", "world", tags=[_SESSION_TAG])
+    run_kwargs: dict[str, object] = {"tags": [_SESSION_TAG]}
+    if configured_runner_ids is not None:
+        run_kwargs["runner_ids"] = list(configured_runner_ids)
+    sandbox = Sandbox.run("echo", "hello", "world", **run_kwargs)
 
     try:
         assert sandbox.sandbox_id is not None
@@ -48,10 +53,15 @@ def test_sandbox_run_factory_no_defaults() -> None:
         sandbox.stop().result()
 
 
-def test_sandbox_no_defaults_max_lifetime_only() -> None:
+def test_sandbox_no_defaults_max_lifetime_only(
+    configured_runner_ids: tuple[str, ...] | None,
+) -> None:
     """Test sandbox creation with only max_lifetime_seconds configured."""
     defaults = SandboxDefaults(max_lifetime_seconds=60)
-    sandbox = Sandbox.run("echo", "hello", "world", defaults=defaults, tags=[_SESSION_TAG])
+    run_kwargs: dict[str, object] = {"tags": [_SESSION_TAG]}
+    if configured_runner_ids is not None:
+        run_kwargs["runner_ids"] = list(configured_runner_ids)
+    sandbox = Sandbox.run("echo", "hello", "world", defaults=defaults, **run_kwargs)
 
     try:
         assert sandbox.sandbox_id is not None
@@ -59,20 +69,33 @@ def test_sandbox_no_defaults_max_lifetime_only() -> None:
         sandbox.stop().result()
 
 
-def test_sandbox_no_defaults_tags_only() -> None:
+def test_sandbox_no_defaults_tags_only(
+    configured_runner_ids: tuple[str, ...] | None,
+) -> None:
     """Test sandbox creation with only tags configured."""
     defaults = SandboxDefaults(tags=("isolation-test", _SESSION_TAG))
-    sandbox = Sandbox.run("echo", "hello", "world", defaults=defaults)
+    run_kwargs: dict[str, object] = {}
+    if configured_runner_ids is not None:
+        run_kwargs["runner_ids"] = list(configured_runner_ids)
+    sandbox = Sandbox.run("echo", "hello", "world", defaults=defaults, **run_kwargs)
 
     try:
+        sandbox.wait()
         assert sandbox.sandbox_id is not None
+        if configured_runner_ids is not None:
+            assert sandbox.runner_id in configured_runner_ids
     finally:
         sandbox.stop().result()
 
 
-def test_sandbox_no_defaults_sleep_command() -> None:
+def test_sandbox_no_defaults_sleep_command(
+    configured_runner_ids: tuple[str, ...] | None,
+) -> None:
     """Test sandbox creation with sleep infinity command and no defaults."""
-    sandbox = Sandbox.run("sleep", "infinity", tags=[_SESSION_TAG])
+    run_kwargs: dict[str, object] = {"tags": [_SESSION_TAG]}
+    if configured_runner_ids is not None:
+        run_kwargs["runner_ids"] = list(configured_runner_ids)
+    sandbox = Sandbox.run("sleep", "infinity", **run_kwargs)
 
     try:
         assert sandbox.sandbox_id is not None
@@ -92,15 +115,20 @@ def test_sandbox_file_operations(sandbox_defaults: SandboxDefaults) -> None:
         assert content == test_content
 
 
-def test_sandbox_with_defaults() -> None:
+def test_sandbox_with_defaults(
+    configured_runner_ids: tuple[str, ...] | None,
+) -> None:
     """Test sandbox creation with SandboxDefaults."""
     defaults = SandboxDefaults(
         max_lifetime_seconds=60,
         tags=("test-integration",),
         resources={"cpu": "500m", "memory": "256Mi"},
     )
+    run_kwargs: dict[str, object] = {}
+    if configured_runner_ids is not None:
+        run_kwargs["runner_ids"] = list(configured_runner_ids)
 
-    with Sandbox.run("sleep", "infinity", defaults=defaults) as sandbox:
+    with Sandbox.run("sleep", "infinity", defaults=defaults, **run_kwargs) as sandbox:
         assert sandbox.sandbox_id is not None
 
         result = sandbox.exec(["python", "--version"]).result()
@@ -108,15 +136,18 @@ def test_sandbox_with_defaults() -> None:
         assert "Python 3.11" in result.stdout
 
 
-def test_sandbox_burstable_qos_resources(sandbox_defaults: SandboxDefaults) -> None:
+def test_sandbox_burstable_qos_resources(
+    sandbox_defaults: SandboxDefaults,
+    configured_runner_ids: tuple[str, ...] | None,
+) -> None:
     """Test sandbox creation with distinct requests and limits (Burstable QoS).
 
     Uses ResourceOptions with requests < limits to exercise the overcommit path,
     which maps to separate resource_requests and resource_limits proto fields.
+    Inherits the runner pin via ``sandbox_defaults.with_overrides(...)`` so the
+    bespoke resources do not drop the pin.
     """
-    defaults = SandboxDefaults(
-        max_lifetime_seconds=60,
-        tags=("integration-test",),
+    defaults = sandbox_defaults.with_overrides(
         resources=ResourceOptions(
             requests={"cpu": "500m", "memory": "512Mi"},
             limits={"cpu": "1", "memory": "1Gi"},
@@ -127,6 +158,8 @@ def test_sandbox_burstable_qos_resources(sandbox_defaults: SandboxDefaults) -> N
         sandbox.wait()
         assert sandbox.sandbox_id is not None
         assert sandbox.status == "running"
+        if configured_runner_ids is not None:
+            assert sandbox.runner_id in configured_runner_ids
 
         assert sandbox.resource_requests is not None
         assert sandbox.resource_limits is not None
@@ -522,16 +555,30 @@ def test_sandbox_with_runway_and_runner_ids(sandbox_defaults: SandboxDefaults) -
             assert targeted_sandbox.sandbox_id is not None
             assert targeted_sandbox.status == "running"
 
-            # The sandbox should land on the specified runway/tower
-            assert targeted_sandbox.profile_id is not None
-            assert targeted_sandbox.runner_id is not None
+            # The backend must place the sandbox on the requested infrastructure.
+            assert targeted_sandbox.profile_id == discovered_profile_id
+            assert targeted_sandbox.runner_id == discovered_runner_id
 
 
-def test_sandbox_with_empty_runway_and_runner_ids(sandbox_defaults: SandboxDefaults) -> None:
+def test_sandbox_with_empty_runway_and_runner_ids(
+    sandbox_defaults: SandboxDefaults,
+    configured_runner_ids: tuple[str, ...] | None,
+) -> None:
     """Test sandbox creation with empty profile_ids and runner_ids lists.
 
-    Verifies that empty lists are accepted (clearing any defaults).
+    Verifies that empty lists are accepted (clearing any defaults). This test
+    is a documented opt-out from the runner-pin contract in tests/AGENTS.md:
+    its whole purpose is to exercise auto-scheduling by clearing defaults, so
+    it cannot honor the pin. Skipped under runner-pin rollouts to avoid
+    landing on an unpinned runner and masquerading as a regression in the PR
+    under test.
     """
+    if configured_runner_ids is not None:
+        pytest.skip(
+            "Opt-out test clears runner_ids to exercise auto-scheduling; "
+            "skipped under runner-pin rollouts"
+        )
+
     with Sandbox.run(
         profile_ids=[],
         runner_ids=[],


### PR DESCRIPTION
## Summary

Close the bypass that let a handful of e2e tests ignore `CWSANDBOX_TEST_RUNNER_IDS` / `--cwsandbox-runner-ids` by constructing their own `SandboxDefaults` or calling `Sandbox.run()` without defaults. During a runner-scoped rollout pinned to one runner, those tests auto-scheduled elsewhere and hit transient gateway errors during `stop()`, masquerading as regressions in the PR under test. Now every call site either inherits the pin via `sandbox_defaults` or explicitly forwards it via a new `configured_runner_ids` fixture, with placement assertions making the guarantee self-verifying when a pin is active.

## Design Decisions

**Fixture over plain helper for test-facing access.** Exposing `configured_runner_ids` as a session-scoped pytest fixture gives a single canonical way for tests to read the resolved runner IDs. The underlying `_resolve_runner_ids` helper stays a private implementation detail shared with the existing validation fixture. Tests that already use `sandbox_defaults` inherit the pin transparently; tests that construct their own defaults opt in explicitly.

**Forward `runner_ids` at the `Sandbox.run()` call site, not into `SandboxDefaults(...)`.** The whole point of the minimal-defaults bypass tests is to verify specific `SandboxDefaults` shapes (tags-only, max-lifetime-only, etc.). Injecting `runner_ids` into the constructor would change what each test is exercising. Forwarding at the call site preserves the constructor intent while still applying the pin, because explicit `Sandbox.run(..., runner_ids=...)` kwargs override defaults at the SDK level.

**Refactor `test_sandbox_burstable_qos_resources` to use `sandbox_defaults.with_overrides(resources=...)` rather than call-site forwarding.** This test previously hand-rolled a fresh `SandboxDefaults` and discarded the fixture. Switching to `with_overrides` preserves the intent of the test (burstable QoS via overcommit) while transitively inheriting the runner pin, and demonstrates the defaults-inheritance forwarding pattern end-to-end.

**Placement assertions on exactly two tests, not all five.** `runner_id` is only populated after the sandbox leaves `_Starting`, so asserting placement requires `sandbox.wait()` - which would change the runtime and purpose of the minimal-defaults smoke tests. One assertion for the call-site kwarg pattern (`test_sandbox_no_defaults_tags_only`) and one for the defaults-inheritance pattern (`test_sandbox_burstable_qos_resources`) is enough to self-verify both forwarding shapes without ballooning test time.

**Opt-out `test_sandbox_with_empty_runway_and_runner_ids` under a configured pin.** This test passes `runner_ids=[]` specifically to exercise the "clear defaults" semantic, so it cannot honor the pin by design. Under a runner-scoped rollout, that left it exposed to the exact flake pattern the epic targets. It now skips when `configured_runner_ids` is set - the "empty clears defaults" contract is a client-side concern already covered by unit tests, so the e2e path adds no unique coverage during pinned runs.

**Document the contract in `tests/AGENTS.md`.** A prose contract ("any test that may create a sandbox MUST honor the pin via one of these two paths") is more durable than trying to enforce runner-pin propagation structurally. It also names the legitimate opt-out (tests validating `runner_ids` semantics) so future reviewers can tell intentional bypass from accidental regression.

**Strengthen the opt-out exemplar's assertions.** `test_sandbox_with_runway_and_runner_ids` is the test this PR promotes in `tests/AGENTS.md` as the reference example of a legitimate opt-out. Its original assertions (`profile_id is not None`, `runner_id is not None`) would pass even if the backend silently dropped the targeting kwargs. Tightened to equality against the discovered IDs so the exemplar actually verifies the targeting semantic it claims to.

## Testing

- `mise run lint:check` - PASS
- `mise run typecheck` - PASS
- `mise run test` (unit) - PASS
- `mise run test:e2e:parallel` (baseline, no pin) - all previously-bypassing tests PASS. Suite had unrelated failures clustered on one xdist worker (session and wandb tests, plus pre-existing stdin and read_nonexistent_file failures); those exhibit the same transient gateway flake pattern this PR exists to mitigate.
- `mise run test:e2e:parallel -- --cwsandbox-runner-ids=scale-test-east-13-managed` (pinned) - all previously-bypassing tests PASS and placement assertions confirm they landed on the pinned runner. The two remaining failures are `test_sandbox_read_nonexistent_file` (pre-existing, unrelated) and `test_sandbox_with_empty_runway_and_runner_ids` (now skipped by design under a configured pin).
- `uv run pytest tests/integration/cwsandbox/test_sandbox.py::test_sandbox_with_runway_and_runner_ids` with the pin set - PASS; the strengthened equality assertions (`profile_id == discovered_profile_id` / `runner_id == discovered_runner_id`) hold end-to-end against the real backend.
