### PR TITLE
fix: trap SIGTERM in default keep-alive command 

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,7 +125,7 @@ Utility methods:
 
 Key constants (from `_defaults.py`):
 - `DEFAULT_CONTAINER_IMAGE = "python:3.11"`
-- `DEFAULT_COMMAND = "tail"`, `DEFAULT_ARGS = ("-f", "/dev/null")`
+- `DEFAULT_COMMAND = "/bin/sh"`, `DEFAULT_ARGS = ("-c", 'trap "exit 0" TERM INT; sleep infinity & wait')` - shell-trapped keep-alive so PID 1 responds to SIGTERM on stop
 - `DEFAULT_BASE_URL = "https://api.cwsandbox.com"`
 - `DEFAULT_REQUEST_TIMEOUT_SECONDS = 300.0` - Client-side HTTP timeout
 - `DEFAULT_MAX_LIFETIME_SECONDS = None` - Server controls sandbox lifetime

--- a/src/cwsandbox/_defaults.py
+++ b/src/cwsandbox/_defaults.py
@@ -11,8 +11,13 @@ from typing import Any
 from cwsandbox._types import NetworkOptions, ResourceOptions, Secret
 
 DEFAULT_CONTAINER_IMAGE: str = "python:3.11"
-DEFAULT_COMMAND: str = "tail"
-DEFAULT_ARGS: tuple[str, ...] = ("-f", "/dev/null")
+# Shell-trapped keep-alive: installs an explicit SIGTERM handler so the PID 1
+# process actually responds to stop signals instead of waiting out the full
+# terminationGracePeriodSeconds. `tail -f /dev/null` does not install a
+# handler and gets silently ignored, which has triggered production node
+# drains via SUNK's scheduler-epilog timeout.
+DEFAULT_COMMAND: str = "/bin/sh"
+DEFAULT_ARGS: tuple[str, ...] = ("-c", 'trap "exit 0" TERM INT; sleep infinity & wait')
 DEFAULT_BASE_URL: str = "https://api.cwsandbox.com"
 DEFAULT_GRACEFUL_SHUTDOWN_SECONDS: float = 10.0
 DEFAULT_POLL_INTERVAL_SECONDS: float = 0.2
@@ -102,8 +107,8 @@ class SandboxDefaults:
         ```python
         defaults = SandboxDefaults(
             container_image="python:3.12",
-            command="tail",
-            args=("-f", "/dev/null"),
+            command="/bin/sh",
+            args=("-c", 'trap "exit 0" TERM INT; sleep infinity & wait'),
             request_timeout_seconds=60,
             max_lifetime_seconds=3600,  # 1 hour sandbox lifetime
             tags=("my-workload", "experiment-42"),

--- a/src/cwsandbox/_sandbox.py
+++ b/src/cwsandbox/_sandbox.py
@@ -666,7 +666,8 @@ class Sandbox:
 
         Does NOT wait for RUNNING status. Use .wait() to block until ready.
         If positional args are provided, the first is the command and the rest
-        are its arguments. If no args are provided, uses defaults (tail -f /dev/null).
+        are its arguments. If no args are provided, uses a shell-trapped
+        keep-alive default that responds to SIGTERM on stop.
 
         Args:
             *args: Optional command and arguments (e.g., "echo", "hello", "world").
@@ -698,7 +699,7 @@ class Sandbox:
 
         Examples:
             ```python
-            # Using defaults (tail -f /dev/null)
+            # Using defaults (shell-trapped keep-alive)
             sb = Sandbox.run()
 
             # Fire and forget style
@@ -3533,16 +3534,15 @@ class Sandbox:
         """Stream logs from the sandbox's main process.
 
         Streams stdout/stderr from the sandbox's **main command** — the
-        entrypoint passed to ``Sandbox.run()`` (or the default
-        ``tail -f /dev/null``). Output from commands started via ``exec()``
-        is **not** included; use ``Process.stdout``/``Process.stderr`` for
-        those.
+        entrypoint passed to ``Sandbox.run()`` (or the default shell-trapped
+        keep-alive). Output from commands started via ``exec()`` is **not**
+        included; use ``Process.stdout``/``Process.stderr`` for those.
 
         .. note::
 
-            Sandboxes created with the default command (``tail -f /dev/null``)
-            do not produce any log output. To see logs here, pass a command
-            that writes to stdout/stderr when calling ``Sandbox.run()``.
+            Sandboxes created with the default keep-alive command do not
+            produce any log output. To see logs here, pass a command that
+            writes to stdout/stderr when calling ``Sandbox.run()``.
 
         Returns a StreamReader that yields log lines as strings. The method
         returns immediately — iteration on the StreamReader blocks until

--- a/src/cwsandbox/cli/logs.py
+++ b/src/cwsandbox/cli/logs.py
@@ -46,8 +46,8 @@ def logs(
     entrypoint passed to Sandbox.run()). Output from exec commands is not
     included — use 'cwsandbox exec' for those.
 
-    Note: sandboxes created with the default command (tail -f /dev/null) do
-    not produce any log output.
+    Note: sandboxes created with the default keep-alive command do not
+    produce any log output.
 
     SANDBOX_ID is the ID of the sandbox to stream logs from.
     """

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -121,8 +121,6 @@ Parsing normalises the list: whitespace is stripped, empty tokens are dropped, a
 
 Scope: this constrains runner placement only. Profile selection remains backend-driven; `container_image`, `resources`, `tags`, `max_lifetime_seconds` are unchanged.
 
-xdist caveat: every xdist worker targets the same runner tuple. When pinning to a single runner, lower `-n` (or run sequential with `mise run test:e2e`) to avoid queueing all workers behind one node.
-
 ### Contract for new e2e tests
 
 Any test path that may create a sandbox - directly via `Sandbox.run()`, indirectly via `Session`, or via a `@session.function()` - MUST honor the configured runner pin. To comply, either:

--- a/tests/integration/cwsandbox/test_sandbox.py
+++ b/tests/integration/cwsandbox/test_sandbox.py
@@ -16,6 +16,7 @@ import pytest
 
 from cwsandbox import NetworkOptions, ResourceOptions, Sandbox, SandboxDefaults, Session
 from cwsandbox._sandbox import SandboxStatus
+from cwsandbox.exceptions import SandboxError
 from tests.integration.cwsandbox.conftest import _SESSION_TAG
 
 
@@ -1302,3 +1303,31 @@ def test_natural_exit_no_raise_on_termination(sandbox_defaults: SandboxDefaults)
         SandboxStatus.FAILED,
         SandboxStatus.TERMINATED,
     )
+
+
+def test_default_command_produces_no_logs(sandbox_defaults: SandboxDefaults) -> None:
+    """The default keep-alive command is silent on stdout/stderr while running.
+
+    The docs advertise that the default produces no log output. A regression
+    here usually means the shell is emitting job-control chatter (e.g.
+    "[1] 5 terminated"), which would surprise users tailing logs and break
+    the advertised contract. Post-stop logs are not checked: the backend
+    may reap completed sandboxes before the follow-up stream_logs call can
+    reach them, which is orthogonal to the log-silence contract.
+    """
+    sandbox = Sandbox.run(defaults=sandbox_defaults)
+    try:
+        sandbox.wait()
+        assert sandbox.status == SandboxStatus.RUNNING
+
+        reader = sandbox.stream_logs(tail_lines=10)
+        try:
+            lines = list(reader)
+        finally:
+            reader.close()
+        assert lines == [], f"default command produced log output: {lines!r}"
+    finally:
+        try:
+            sandbox.stop(missing_ok=True).result()
+        except SandboxError:
+            pass

--- a/tests/unit/cwsandbox/test_defaults.py
+++ b/tests/unit/cwsandbox/test_defaults.py
@@ -338,7 +338,7 @@ class TestSandboxDefaultsFromDict:
             }
         )
         assert defaults.tags == ()
-        assert defaults.args == ("-f", "/dev/null")
+        assert defaults.args == ("-c", 'trap "exit 0" TERM INT; sleep infinity & wait')
         assert defaults.environment_variables == {}
 
     def test_from_dict_drops_none_for_scalar_fields(self) -> None:
@@ -353,7 +353,7 @@ class TestSandboxDefaultsFromDict:
             }
         )
         assert defaults.container_image == "python:3.11"
-        assert defaults.command == "tail"
+        assert defaults.command == "/bin/sh"
         assert defaults.base_url == "https://api.cwsandbox.com"
         assert defaults.temp_dir == "/tmp"
         assert defaults.request_timeout_seconds == 300.0

--- a/tests/unit/cwsandbox/test_sandbox.py
+++ b/tests/unit/cwsandbox/test_sandbox.py
@@ -292,9 +292,12 @@ class TestSandboxRun:
             sandbox = Sandbox.run()
             mock_start.assert_called_once()
             mock_ref.result.assert_called_once()
-            # Default command is "tail" with args ["-f", "/dev/null"]
-            assert sandbox._command == "tail"
-            assert sandbox._args == ["-f", "/dev/null"]
+            # Default is a shell-trapped keep-alive so PID 1 responds to SIGTERM
+            assert sandbox._command == "/bin/sh"
+            assert sandbox._args == [
+                "-c",
+                'trap "exit 0" TERM INT; sleep infinity & wait',
+            ]
 
     def test_run_calls_start(self) -> None:
         """Test Sandbox.run calls start().result() on the sandbox."""

--- a/tests/unit/cwsandbox/test_session.py
+++ b/tests/unit/cwsandbox/test_session.py
@@ -24,6 +24,22 @@ class TestSessionSandbox:
 
         assert isinstance(sandbox, Sandbox)
 
+    def test_sandbox_no_command_uses_shell_trap_default(self) -> None:
+        """Session.sandbox() without a command falls back to the SIGTERM-trap default.
+
+        Covers the session-defaulting path: if neither the caller nor custom
+        defaults supply a command, the SDK must use the shell-trapped keep-alive
+        so PID 1 responds to SIGTERM on stop.
+        """
+        session = Session()
+        sandbox = session.sandbox()
+
+        assert sandbox._command == "/bin/sh"
+        assert sandbox._args == [
+            "-c",
+            'trap "exit 0" TERM INT; sleep infinity & wait',
+        ]
+
     def test_sandbox_inherits_environment_variables_from_session_defaults(self) -> None:
         """Test session.sandbox inherits environment variables from session defaults."""
         from cwsandbox import SandboxDefaults


### PR DESCRIPTION
## Summary

The SDK's default sandbox keep-alive command ran `tail -f /dev/null` as PID 1. Linux does not deliver default signal actions to PID 1 unless a handler is installed, so SIGTERM was silently dropped on every stop. Pods waited out the full `terminationGracePeriodSeconds` (30s) before SIGKILL, which tripped SUNK's scheduler-epilog timeout at ~28s and drained a production node. This PR replaces the default with a shell-trapped variant so PID 1 actually responds to stop.

## Design Decisions

- **`/bin/sh -c 'trap "exit 0" TERM INT; sleep infinity & wait'`.** `trap` installs an explicit handler; `sleep infinity &` plus `wait` lets the shell block on a signal-interruptible primitive rather than `sleep infinity` directly (which some shells cannot interrupt mid-call on every platform).
- **`exit 0` on SIGTERM rather than `exit 143`.** A user-initiated stop is a normal termination, so the clean exit keeps stop-initiated sandboxes in `COMPLETED` rather than `FAILED` and doesn't regress anyone relying on the returncode.
- **`/bin/sh` (absolute path) over `sh`.** Stricter guarantee, avoids PATH-resolution edge cases, and matches the shell-dependency language already in `AGENTS.md`.
- **No new integration latency test.** An earlier draft of this branch included `test_default_command_stop_latency`. On review, the unit tests in `test_defaults.py`, `test_sandbox.py`, and `test_session.py` already assert the exact trap'd default string, and the integration timing asserts a property of backend pod-deletion that varies with cluster load and StatusWatcher cadence. Keeping the latency check would add flake without catching a regression the unit layer misses. `test_default_command_produces_no_logs` stays because it asserts a distinct, deterministic user-visible contract (the default is silent on stdout/stderr).
- **Scratch/distroless images.** Still incompatible with shell-based defaults — they were with the old `tail -f /dev/null` default too. No regression; users on those images already supply their own command.

The companion commit removes an outdated note in `tests/AGENTS.md` that advised dropping xdist concurrency when pinning to a single runner. The backend runners handle parallel workers fine; the note only misled future readers.

## Testing

- `mise run format:check` — PASS
- `mise run lint:check` — PASS
- `mise run typecheck` — PASS
- `mise run test` (unit) — PASS
- `mise run test:e2e:parallel` — PASS
