### PR TITLE
docs: clarify mounted_files are read-only at runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ Properties:
 
 Advanced configuration kwargs (for `run()`, `Session.sandbox()`, and `@session.function()`):
 - `resources` - Resource configuration via `ResourceOptions`, nested dict, or legacy flat dict (CPU, memory, GPU)
-- `mounted_files` - Files to mount into the sandbox
+- `mounted_files` - Files to mount into the sandbox at startup (read-only at runtime; use `write_file()` for writable files)
 - `s3_mount` - S3 bucket mount configuration
 - `ports` - Port mappings for the sandbox
 - `network` - Network configuration via `NetworkOptions` or dict (ingress/egress modes, exposed ports)

--- a/src/cwsandbox/_function.py
+++ b/src/cwsandbox/_function.py
@@ -113,7 +113,10 @@ class RemoteFunction(Generic[P, R]):
             runner_ids: Optional list of runner IDs
             resources: Resource configuration. Accepts ResourceOptions for separate
                 requests/limits, or a flat dict for backward-compatible Guaranteed QoS.
-            mounted_files: Files to mount into the sandbox
+            mounted_files: Files to mount into the sandbox at startup. Each dict
+                should have ``mount_path`` (str) and ``file_content`` (bytes).
+                Note: Mounted files are read-only at runtime. To modify a file,
+                use ``sandbox.write_file()`` after the sandbox is running.
             s3_mount: S3 bucket mount configuration
             ports: Port mappings for the sandbox
             network: Network configuration (NetworkOptions dataclass)

--- a/src/cwsandbox/_sandbox.py
+++ b/src/cwsandbox/_sandbox.py
@@ -567,7 +567,10 @@ class Sandbox:
             runner_ids: Optional list of runner IDs
             resources: Resource configuration. Accepts ResourceOptions for separate
                 requests/limits, or a flat dict for backward-compatible Guaranteed QoS.
-            mounted_files: Files to mount into the sandbox
+            mounted_files: Files to mount into the sandbox at startup. Each dict
+                should have ``mount_path`` (str) and ``file_content`` (bytes).
+                Note: Mounted files are read-only at runtime. To modify a file,
+                use ``sandbox.write_file()`` after the sandbox is running.
             s3_mount: S3 bucket mount configuration
             ports: Port mappings for the sandbox
             network: Network configuration (NetworkOptions dataclass)
@@ -778,7 +781,10 @@ class Sandbox:
             runner_ids: Optional list of runner IDs
             resources: Resource configuration. Accepts ResourceOptions for separate
                 requests/limits, or a flat dict for backward-compatible Guaranteed QoS.
-            mounted_files: Files to mount into the sandbox
+            mounted_files: Files to mount into the sandbox at startup. Each dict
+                should have ``mount_path`` (str) and ``file_content`` (bytes).
+                Note: Mounted files are read-only at runtime. To modify a file,
+                use ``sandbox.write_file()`` after the sandbox is running.
             s3_mount: S3 bucket mount configuration
             ports: Port mappings for the sandbox
             network: Network configuration (NetworkOptions dataclass)

--- a/src/cwsandbox/_session.py
+++ b/src/cwsandbox/_session.py
@@ -356,7 +356,10 @@ class Session:
             runner_ids: Optional list of runner IDs
             resources: Resource configuration. Accepts ResourceOptions for separate
                 requests/limits, or a flat dict for backward-compatible Guaranteed QoS.
-            mounted_files: Files to mount into the sandbox
+            mounted_files: Files to mount into the sandbox at startup. Each dict
+                should have ``mount_path`` (str) and ``file_content`` (bytes).
+                Note: Mounted files are read-only at runtime. To modify a file,
+                use ``sandbox.write_file()`` after the sandbox is running.
             s3_mount: S3 bucket mount configuration
             ports: Port mappings for the sandbox
             network: Network configuration (NetworkOptions dataclass)
@@ -683,7 +686,10 @@ class Session:
             runner_ids: Optional list of runner IDs
             resources: Resource configuration. Accepts ResourceOptions for separate
                 requests/limits, or a flat dict for backward-compatible Guaranteed QoS.
-            mounted_files: Files to mount into the sandbox
+            mounted_files: Files to mount into the sandbox at startup. Each dict
+                should have ``mount_path`` (str) and ``file_content`` (bytes).
+                Note: Mounted files are read-only at runtime. To modify a file,
+                use ``sandbox.write_file()`` after the sandbox is running.
             s3_mount: S3 bucket mount configuration
             ports: Port mappings for the sandbox
             network: Network configuration (NetworkOptions dataclass)


### PR DESCRIPTION
Update docstrings across Sandbox.run(), Session.sandbox(), and
@session.function() to document that mounted files are read-only
and suggest using write_file() for writable files.

https://claude.ai/code/session_01BrtogWK3Y6KWdcLNsKxxJV