### PR TITLE
docs: flush stdout in async TerminalSession example

### DIFF
--- a/src/cwsandbox/_types.py
+++ b/src/cwsandbox/_types.py
@@ -768,6 +768,8 @@ class TerminalSession(OperationRef["TerminalResult"]):
     Examples:
         SDK-level interactive session:
         ```python
+        import sys
+
         session = sandbox.shell(width=80, height=24)
         for chunk in session.output:
             sys.stdout.buffer.write(chunk)
@@ -777,9 +779,12 @@ class TerminalSession(OperationRef["TerminalResult"]):
 
         Async usage:
         ```python
+        import sys
+
         session = sandbox.shell()
         async for chunk in session.output:
             sys.stdout.buffer.write(chunk)
+            sys.stdout.buffer.flush()
         result = await session
         ```
     """


### PR DESCRIPTION
## Summary

The async `TerminalSession` docstring example wrote to
`sys.stdout.buffer` without flushing, contradicting the class's
documented "no output buffering" behavior - output would sit in the
buffer until process exit instead of streaming. Adds `flush()` for
parity with the sync fence.

Also picks up the missing `import sys` to keep this docstring in sync
with coreweave/docs#3032, so the next regen of `ref/core/sandbox.mdx`
doesn't undo it.

## Testing

- [x] `mise run format:check` / `lint:check` / `typecheck` / `test`