### PR TITLE
fix: Raise gRPC message limit for file operations

### DIFF
--- a/src/cwsandbox/_defaults.py
+++ b/src/cwsandbox/_defaults.py
@@ -32,6 +32,9 @@ DEFAULT_REQUEST_TIMEOUT_SECONDS: float = 300.0
 # Timeout for lightweight discovery RPCs (list/get runners and profiles).
 DEFAULT_DISCOVERY_TIMEOUT_SECONDS: float = 30.0
 
+# Match the backend's default gRPC message-size limit for unary RPCs.
+DEFAULT_GRPC_MAX_MESSAGE_LENGTH_BYTES: int = 100 * 1024 * 1024
+
 # Wall-clock budget per retry burst (one trip to a stable status) on poll
 # RPCs.  The budget resets on any successful response, so a long-lived
 # sandbox that hits a transient error, recovers, then hits another much

--- a/src/cwsandbox/_network.py
+++ b/src/cwsandbox/_network.py
@@ -21,6 +21,7 @@ from urllib.parse import urlparse
 import grpc
 import grpc.aio
 
+from cwsandbox._defaults import DEFAULT_GRPC_MAX_MESSAGE_LENGTH_BYTES
 from cwsandbox._error_info import ParsedError, parse_error_info
 from cwsandbox.exceptions import CWSandboxAuthenticationError, CWSandboxError
 
@@ -62,6 +63,13 @@ def parse_grpc_target(base_url: str) -> tuple[str, bool]:
     return target, is_secure
 
 
+def _default_channel_options() -> tuple[tuple[str, int], ...]:
+    return (
+        ("grpc.max_send_message_length", DEFAULT_GRPC_MAX_MESSAGE_LENGTH_BYTES),
+        ("grpc.max_receive_message_length", DEFAULT_GRPC_MAX_MESSAGE_LENGTH_BYTES),
+    )
+
+
 def create_channel(
     target: str,
     is_secure: bool,
@@ -75,11 +83,12 @@ def create_channel(
     Returns:
         An async gRPC channel
     """
+    options = _default_channel_options()
     if is_secure:
         credentials = grpc.ssl_channel_credentials()
-        return grpc.aio.secure_channel(target, credentials)
+        return grpc.aio.secure_channel(target, credentials, options=options)
     else:
-        return grpc.aio.insecure_channel(target)
+        return grpc.aio.insecure_channel(target, options=options)
 
 
 def translate_grpc_error(

--- a/tests/integration/cwsandbox/test_sandbox.py
+++ b/tests/integration/cwsandbox/test_sandbox.py
@@ -136,6 +136,18 @@ def test_sandbox_file_operations(sandbox_defaults: SandboxDefaults) -> None:
         assert content == test_content
 
 
+def test_sandbox_large_file_operations(sandbox_defaults: SandboxDefaults) -> None:
+    """Test file operations above grpcio's historical 4 MiB default."""
+    with Sandbox.run(defaults=sandbox_defaults) as sandbox:
+        payload = bytes(i % 251 for i in range(5 * 1024 * 1024))
+        filepath = f"/tmp/test_large_file_{uuid.uuid4().hex}.bin"
+
+        sandbox.write_file(filepath, payload).result()
+        content = sandbox.read_file(filepath).result()
+
+        assert content == payload
+
+
 def test_sandbox_with_defaults(
     configured_runner_ids: tuple[str, ...] | None,
 ) -> None:

--- a/tests/unit/cwsandbox/test_network.py
+++ b/tests/unit/cwsandbox/test_network.py
@@ -15,6 +15,7 @@ from google.protobuf.duration_pb2 import Duration
 from google.rpc import error_details_pb2, status_pb2
 
 from cwsandbox._network import (
+    _default_channel_options,
     create_channel,
     paginate_async,
     parse_grpc_target,
@@ -137,6 +138,7 @@ class TestCreateChannel:
         mock_secure_channel.assert_called_once_with(
             "atc.example.com:443",
             mock_creds,
+            options=_default_channel_options(),
         )
         assert result is mock_channel
 
@@ -148,7 +150,10 @@ class TestCreateChannel:
 
         result = create_channel("localhost:50051", is_secure=False)
 
-        mock_insecure_channel.assert_called_once_with("localhost:50051")
+        mock_insecure_channel.assert_called_once_with(
+            "localhost:50051",
+            options=_default_channel_options(),
+        )
         assert result is mock_channel
 
 


### PR DESCRIPTION
## Summary

Python grpcio defaults can reject unary messages above 4 MiB even when the Sandbox backend is configured for its current 100 MiB default. That left ordinary `read_file()` and `write_file()` calls failing below the backend's intended limit, including the file-operation repro from issue #31.

This change aligns the Python client's default gRPC send and receive message limits with the backend default. The limit is a serialized gRPC/protobuf message-size limit, not an exact file-byte guarantee, so callers near the nominal boundary can still hit framing overhead.

## Testing

- `uv run pytest tests/unit/cwsandbox/test_network.py -v`
- `uv run pytest`
- `uv run pytest tests/integration/cwsandbox/test_sandbox.py::test_sandbox_large_file_operations -v`
