### PR TITLE
fix: reject bare string sandbox tags

### DIFF
--- a/src/cwsandbox/_defaults.py
+++ b/src/cwsandbox/_defaults.py
@@ -111,6 +111,24 @@ def _merge_dicts(base: dict[str, str], additional: dict[str, str] | None) -> dic
     return merged
 
 
+def _normalize_tags(tags: Iterable[str] | None) -> tuple[str, ...]:
+    """Normalize tag sequences and reject bare strings.
+
+    Strings are iterable in Python, so accepting one would split it into
+    characters (``"prod"`` -> ``("p", "r", "o", "d")``).
+    """
+    if tags is None:
+        return ()
+    if isinstance(tags, str):
+        raise TypeError("tags must be a sequence of strings, not a bare string")
+
+    normalized = tuple(tags)
+    for tag in normalized:
+        if not isinstance(tag, str):
+            raise TypeError("tags must contain only strings")
+    return normalized
+
+
 def _validate_poll_config(
     poll_retry_budget_seconds: float,
     poll_rpc_timeout_seconds: float,
@@ -228,16 +246,17 @@ class SandboxDefaults:
             self.poll_retry_budget_seconds,
             self.poll_rpc_timeout_seconds,
         )
+        object.__setattr__(self, "tags", _normalize_tags(self.tags))
 
-    def merge_tags(self, additional: list[str] | None) -> list[str]:
+    def merge_tags(self, additional: Iterable[str] | None) -> list[str]:
         """Combine default tags with additional tags.
 
         Tags from both sources are included. Order is: defaults first,
         then additional tags appended.
         """
-        base = list(self.tags)
-        if additional:
-            base.extend(additional)
+        base = list(_normalize_tags(self.tags))
+        if additional is not None:
+            base.extend(_normalize_tags(additional))
         return base
 
     def merge_environment_variables(self, additional: dict[str, str] | None) -> dict[str, str]:

--- a/src/cwsandbox/_defaults.py
+++ b/src/cwsandbox/_defaults.py
@@ -254,7 +254,7 @@ class SandboxDefaults:
         Tags from both sources are included. Order is: defaults first,
         then additional tags appended.
         """
-        base = list(_normalize_tags(self.tags))
+        base = list(self.tags)
         if additional is not None:
             base.extend(_normalize_tags(additional))
         return base

--- a/src/cwsandbox/_sandbox.py
+++ b/src/cwsandbox/_sandbox.py
@@ -40,6 +40,7 @@ from cwsandbox._defaults import (
     STREAMING_OUTPUT_QUEUE_SIZE,
     STREAMING_RESPONSE_QUEUE_SIZE,
     SandboxDefaults,
+    _normalize_tags,
     _resolve_selector,
     _validate_poll_config,
 )
@@ -1075,6 +1076,7 @@ class Sandbox:
         poll_rpc_timeout_seconds: float | None = None,
     ) -> builtins.list[Sandbox]:
         """Internal async: List existing sandboxes with optional filters."""
+        normalized_tags = _normalize_tags(tags)
         effective_base_url = (
             base_url or os.environ.get("CWSANDBOX_BASE_URL") or DEFAULT_BASE_URL
         ).rstrip("/")
@@ -1105,8 +1107,8 @@ class Sandbox:
 
         try:
             request_kwargs: dict[str, Any] = {}
-            if tags:
-                request_kwargs["tags"] = tags
+            if normalized_tags:
+                request_kwargs["tags"] = list(normalized_tags)
             if status_enum:
                 request_kwargs["status"] = status_enum.to_proto()
             if profile_ids is not None:

--- a/tests/unit/cwsandbox/test_defaults.py
+++ b/tests/unit/cwsandbox/test_defaults.py
@@ -80,6 +80,29 @@ class TestSandboxDefaults:
 
         assert result == ["default-1", "default-2", "additional-1", "additional-2"]
 
+    def test_constructor_normalizes_list_tags(self) -> None:
+        """Test SandboxDefaults normalizes tag sequences to an immutable tuple."""
+        defaults = SandboxDefaults(tags=["tag-1", "tag-2"])  # type: ignore[arg-type]
+
+        assert defaults.tags == ("tag-1", "tag-2")
+
+    def test_constructor_rejects_bare_string_tags(self) -> None:
+        """Test SandboxDefaults rejects bare string tags."""
+        with pytest.raises(TypeError, match="tags must be a sequence of strings"):
+            SandboxDefaults(tags="prod")  # type: ignore[arg-type]
+
+    def test_constructor_rejects_non_string_tag(self) -> None:
+        """Test SandboxDefaults rejects non-string tag values."""
+        with pytest.raises(TypeError, match="tags must contain only strings"):
+            SandboxDefaults(tags=("prod", 123))  # type: ignore[arg-type]
+
+    def test_merge_tags_rejects_bare_string(self) -> None:
+        """Test merge_tags rejects bare string tags."""
+        defaults = SandboxDefaults()
+
+        with pytest.raises(TypeError, match="tags must be a sequence of strings"):
+            defaults.merge_tags("prod")
+
     def test_with_overrides_creates_new(self) -> None:
         """Test with_overrides creates a new instance."""
         defaults = SandboxDefaults(container_image="python:3.11")
@@ -102,6 +125,13 @@ class TestSandboxDefaults:
         assert new_defaults.container_image == "python:3.11"
         assert new_defaults.base_url == "http://example.com"
         assert new_defaults.request_timeout_seconds == 120.0
+
+    def test_with_overrides_rejects_bare_string_tags(self) -> None:
+        """Test with_overrides rejects bare string tags."""
+        defaults = SandboxDefaults()
+
+        with pytest.raises(TypeError, match="tags must be a sequence of strings"):
+            defaults.with_overrides(tags="prod")
 
     def test_merge_environment_variables_empty_base(self) -> None:
         """Test merge_environment_variables with no default environment variables."""

--- a/tests/unit/cwsandbox/test_sandbox.py
+++ b/tests/unit/cwsandbox/test_sandbox.py
@@ -2055,6 +2055,11 @@ class TestSandboxKwargsValidation:
         assert stored[0].env_var == "HF_TOKEN"
         assert sandbox._environment_variables == {"TEST_ENV_VAR": "test-value"}
 
+    def test_init_rejects_bare_string_tags(self) -> None:
+        """Test Sandbox.__init__ rejects bare string tags."""
+        with pytest.raises(TypeError, match="tags must be a sequence of strings"):
+            Sandbox(command="echo", args=["hello"], tags="prod")  # type: ignore[arg-type]
+
     def test_init_with_invalid_kwargs(self) -> None:
         """Test Sandbox.__init__ rejects invalid kwargs."""
         with pytest.raises(TypeError, match="unexpected keyword argument"):
@@ -2376,6 +2381,12 @@ class TestSandboxList:
             assert sandboxes[0].status == "running"
             call_kwargs = mock_stub.List.call_args[1]
             assert call_kwargs["metadata"] == expected_metadata
+
+    @pytest.mark.asyncio
+    async def test_list_rejects_bare_string_tags(self, mock_api_key: str) -> None:
+        """Test list() rejects bare string tags before creating a request."""
+        with pytest.raises(TypeError, match="tags must be a sequence of strings"):
+            await Sandbox.list(tags="prod")  # type: ignore[arg-type]
 
     @pytest.mark.asyncio
     async def test_list_with_status_filter(self, mock_api_key: str) -> None:

--- a/tests/unit/cwsandbox/test_session.py
+++ b/tests/unit/cwsandbox/test_session.py
@@ -580,6 +580,14 @@ class TestSessionList:
             assert "session-tag" in call_args.tags
 
     @pytest.mark.asyncio
+    async def test_list_rejects_bare_string_tags(self, mock_api_key: str) -> None:
+        """Test session.list() rejects bare string tags."""
+        session = Session()
+
+        with pytest.raises(TypeError, match="tags must be a sequence of strings"):
+            await session.list(tags="prod")  # type: ignore[arg-type]
+
+    @pytest.mark.asyncio
     async def test_list_with_adopt_registers_sandboxes(self, mock_api_key: str) -> None:
         """Test session.list(adopt=True) registers sandboxes with session."""
         from google.protobuf import timestamp_pb2


### PR DESCRIPTION
JIRA: https://coreweave.atlassian.net/browse/WB-33933

## Description

Resolves https://github.com/coreweave/aviato/issues/984. Normalize and validate tags so that single string and non-string tags are rejected. 

## Testing

Updated and added unit tests