### PR TITLE
fix: Add exec fallback for oversized file operations

### DIFF
--- a/src/cwsandbox/_defaults.py
+++ b/src/cwsandbox/_defaults.py
@@ -35,6 +35,10 @@ DEFAULT_DISCOVERY_TIMEOUT_SECONDS: float = 30.0
 # Match the backend's default gRPC message-size limit for unary RPCs.
 DEFAULT_GRPC_MAX_MESSAGE_LENGTH_BYTES: int = 100 * 1024 * 1024
 
+# Reserve 1 MiB below the channel limit for protobuf framing on file
+# payloads.  Generous; measured framing on AddFile is far smaller.
+DEFAULT_FILE_UNARY_SAFE_LIMIT_BYTES: int = DEFAULT_GRPC_MAX_MESSAGE_LENGTH_BYTES - 1024 * 1024
+
 # Wall-clock budget per retry burst (one trip to a stable status) on poll
 # RPCs.  The budget resets on any successful response, so a long-lived
 # sandbox that hits a transient error, recovers, then hits another much

--- a/src/cwsandbox/_sandbox.py
+++ b/src/cwsandbox/_sandbox.py
@@ -28,6 +28,7 @@ from cwsandbox._auth import resolve_auth_metadata
 from cwsandbox._defaults import (
     DEFAULT_BASE_URL,
     DEFAULT_CLIENT_TIMEOUT_BUFFER_SECONDS,
+    DEFAULT_FILE_UNARY_SAFE_LIMIT_BYTES,
     DEFAULT_GRACEFUL_SHUTDOWN_SECONDS,
     DEFAULT_MAX_POLL_INTERVAL_SECONDS,
     DEFAULT_POLL_BACKOFF_FACTOR,
@@ -47,6 +48,9 @@ from cwsandbox._defaults import (
 from cwsandbox._error_info import (
     CWSANDBOX_COMMAND_TIMEOUT,
     CWSANDBOX_ERROR_DOMAIN,
+    CWSANDBOX_FILE_IO_FAILED,
+    CWSANDBOX_FILE_IS_DIRECTORY,
+    CWSANDBOX_FILE_NOT_FOUND,
     CWSANDBOX_SANDBOX_NOT_FOUND,
     FILE_ERROR_REASONS,
     UNAVAILABLE_REASONS,
@@ -3046,6 +3050,20 @@ class Sandbox:
             except asyncio.QueueFull:
                 pass
 
+    async def _prepare_streaming_call(
+        self,
+    ) -> streaming_pb2_grpc.GatewayStreamingServiceStub:
+        """Shared StreamExec preamble: ensure running, return a stub."""
+        await self._ensure_started_async()
+        if self._is_done or self._is_stopping:
+            raise SandboxNotRunningError(f"Sandbox {self._sandbox_id} has been stopped")
+        if self._sandbox_id is None:
+            raise SandboxNotRunningError("No sandbox is running")
+        await self._wait_until_running_async()
+        await self._ensure_client()
+        channel = await self._get_or_create_streaming_channel()
+        return streaming_pb2_grpc.GatewayStreamingServiceStub(channel)  # type: ignore[no-untyped-call]
+
     async def _exec_streaming_tty_async(
         self,
         command: Sequence[str],
@@ -3071,18 +3089,7 @@ class Sandbox:
             raise ValueError("Command cannot be empty")
 
         try:
-            await self._ensure_started_async()
-            if self._is_done or self._is_stopping:
-                raise SandboxNotRunningError(f"Sandbox {self._sandbox_id} has been stopped")
-            if self._sandbox_id is None:
-                raise SandboxNotRunningError("No sandbox is running")
-
-            await self._wait_until_running_async()
-
-            await self._ensure_client()
-            channel = await self._get_or_create_streaming_channel()
-            stub = streaming_pb2_grpc.GatewayStreamingServiceStub(channel)  # type: ignore[no-untyped-call]
-
+            stub = await self._prepare_streaming_call()
             auth_metadata = self._auth_metadata
 
             logger.debug(
@@ -3313,19 +3320,7 @@ class Sandbox:
         if not command:
             raise ValueError("Command cannot be empty")
 
-        await self._ensure_started_async()
-        if self._is_done or self._is_stopping:
-            raise SandboxNotRunningError(f"Sandbox {self._sandbox_id} has been stopped")
-        if self._sandbox_id is None:
-            raise SandboxNotRunningError("No sandbox is running")
-
-        # Wait for sandbox to be RUNNING before sending exec request
-        await self._wait_until_running_async()
-
-        await self._ensure_client()
-        channel = await self._get_or_create_streaming_channel()
-        stub = streaming_pb2_grpc.GatewayStreamingServiceStub(channel)  # type: ignore[no-untyped-call]
-
+        stub = await self._prepare_streaming_call()
         auth_metadata = self._auth_metadata
 
         # Wrap command with cwd if provided
@@ -3751,26 +3746,152 @@ class Sandbox:
             resize_queue=resize_queue,
         )
 
-    async def _read_file_async(
+    async def _exec_streaming_binary_async(
         self,
-        filepath: str,
-        timeout: float,
-    ) -> bytes:
-        """Internal async: Read a file from the sandbox filesystem."""
-        await self._ensure_started_async()
-        if self._is_done or self._is_stopping:
-            raise SandboxNotRunningError(f"Sandbox {self._sandbox_id} has been stopped")
-        if self._sandbox_id is None:
-            raise SandboxNotRunningError("No sandbox is running")
+        command: Sequence[str],
+        *,
+        stdin: bytes | None = None,
+        timeout_seconds: float | None = None,
+        operation: str,
+        filepath: str | None = None,
+    ) -> tuple[int, bytes, bytes]:
+        """Run one non-TTY StreamExec and return raw stdout/stderr bytes.
 
-        # Wait for sandbox to be running before file operations
-        await self._wait_until_running_async()
+        See also ``_exec_streaming_async`` — the queue-driven public variant;
+        keep handshake/timeout/error-translation in sync between the two.
+        """
+        timeout = timeout_seconds if timeout_seconds is not None else self._request_timeout_seconds
 
-        await self._ensure_client()
+        if not command:
+            raise ValueError("Command cannot be empty")
+
+        stub = await self._prepare_streaming_call()
+
+        # Cap stderr buffering to defend against runaway error output driving the
+        # client to OOM. Stdout is uncapped because the read fallback needs the
+        # full file body.
+        stderr_cap_bytes = 16384
+        stdout_buffer = bytearray()
+        stderr_buffer: list[bytes] = []
+        stderr_total_bytes = 0
+        stderr_truncated = False
+        exit_code: int | None = None
+        ready_event = asyncio.Event()
+        shutdown_event = asyncio.Event()
+        request_error: Exception | None = None
+
+        async def request_generator() -> AsyncIterator[streaming_pb2.ExecStreamRequest]:
+            yield streaming_pb2.ExecStreamRequest(
+                init=streaming_pb2.ExecStreamInit(
+                    sandbox_id=self._sandbox_id,
+                    command=list(command),
+                )
+            )
+
+            if stdin is None:
+                return
+
+            nonlocal request_error
+            ready_timeout = min(5.0, timeout) if timeout is not None else 5.0
+            try:
+                await asyncio.wait_for(ready_event.wait(), timeout=ready_timeout)
+            except TimeoutError:
+                request_error = SandboxTimeoutError(
+                    "stdin ready signal not received within timeout"
+                )
+                shutdown_event.set()
+                raise request_error from None
+
+            if shutdown_event.is_set():
+                return
+
+            for i in range(0, len(stdin), STDIN_CHUNK_SIZE):
+                if shutdown_event.is_set():
+                    return
+                chunk = stdin[i : i + STDIN_CHUNK_SIZE]
+                yield streaming_pb2.ExecStreamRequest(
+                    stdin=streaming_pb2.ExecStreamData(data=chunk)
+                )
+
+            yield streaming_pb2.ExecStreamRequest(close=streaming_pb2.ExecStreamClose())
+
+        call_timeout = (
+            timeout + DEFAULT_CLIENT_TIMEOUT_BUFFER_SECONDS if timeout is not None else None
+        )
+        call: grpc.aio.StreamStreamCall[
+            streaming_pb2.ExecStreamRequest, streaming_pb2.ExecStreamResponse
+        ] = stub.StreamExec(
+            request_iterator=request_generator(),
+            timeout=call_timeout,
+            metadata=self._auth_metadata,
+        )
+
+        try:
+            async for response in call:
+                if response.HasField("ready"):
+                    ready_event.set()
+                elif response.HasField("output"):
+                    data = response.output.data
+                    stream_type = response.output.stream_type
+                    if stream_type == streaming_pb2.ExecStreamOutput.STREAM_TYPE_STDERR:
+                        if not stderr_truncated:
+                            remaining = stderr_cap_bytes - stderr_total_bytes
+                            if remaining >= len(data):
+                                stderr_buffer.append(data)
+                                stderr_total_bytes += len(data)
+                            else:
+                                if remaining > 0:
+                                    stderr_buffer.append(bytes(data[:remaining]))
+                                    stderr_total_bytes += remaining
+                                stderr_buffer.append(b"... [stderr truncated]")
+                                stderr_truncated = True
+                    else:
+                        stdout_buffer.extend(data)
+                elif response.HasField("exit"):
+                    ready_event.set()
+                    exit_code = response.exit.exit_code
+                    break
+                elif response.HasField("error"):
+                    ready_event.set()
+                    raise SandboxExecutionError(
+                        f"Exec stream error: {response.error.message}",
+                        reason=response.error.code or None,
+                    )
+        except grpc.RpcError as e:
+            # Surface the specific stdin-ready timeout message instead of a
+            # generic CANCELLED translation when grpcio masks request_error
+            # by cancelling the receiver side.
+            if request_error is not None:
+                raise request_error from e
+            raise _translate_rpc_error(
+                e,
+                sandbox_id=self._sandbox_id,
+                operation=operation,
+                filepath=filepath,
+            ) from e
+        finally:
+            ready_event.set()
+            shutdown_event.set()
+            with contextlib.suppress(Exception):
+                call.cancel()
+
+        if request_error is not None:
+            raise request_error
+
+        if exit_code is None:
+            raise SandboxFileError(
+                f"{operation} ended without exit status from sandbox",
+                filepath=filepath,
+            )
+
+        return (
+            exit_code,
+            bytes(stdout_buffer),
+            b"".join(stderr_buffer),
+        )
+
+    async def _read_file_unary_async(self, filepath: str, timeout: float) -> bytes:
         assert self._stub is not None
-
-        logger.debug("Reading file from sandbox %s: %s", self._sandbox_id, filepath)
-
         request = gateway_pb2.RetrieveFileSandboxRequest(
             sandbox_id=self._sandbox_id,
             filepath=filepath,
@@ -3798,6 +3919,87 @@ class Sandbox:
 
         return bytes(response.file_contents)
 
+    async def _read_file_via_exec_streaming(self, filepath: str, timeout: float) -> bytes:
+        script = (
+            "path=$1\n"
+            'if [ ! -e "$path" ]; then\n'
+            '  printf "%s\\n" "File not found: $path" >&2\n'
+            "  exit 2\n"
+            "fi\n"
+            'if [ -d "$path" ]; then\n'
+            '  printf "%s\\n" "Path is a directory: $path" >&2\n'
+            "  exit 3\n"
+            "fi\n"
+            'cat < "$path"\n'
+        )
+        returncode, stdout, stderr = await self._exec_streaming_binary_async(
+            ["/bin/sh", "-c", script, "cwsandbox-read-file", filepath],
+            timeout_seconds=timeout,
+            operation="Read file",
+            filepath=filepath,
+        )
+        if returncode != 0:
+            detail = stderr.decode("utf-8", errors="replace").strip()
+            if not detail:
+                detail = f"fallback command exited with status {returncode}"
+            # Map fallback script exit codes onto the same AIP-193 reasons the
+            # unary path returns, so callers can switch on ``reason`` without
+            # caring which path produced the error.
+            if returncode == 2:
+                raise SandboxFileError(
+                    f"File operation failed ({CWSANDBOX_FILE_NOT_FOUND}): {detail}",
+                    filepath=filepath,
+                    reason=CWSANDBOX_FILE_NOT_FOUND,
+                )
+            if returncode == 3:
+                raise SandboxFileError(
+                    f"File operation failed ({CWSANDBOX_FILE_IS_DIRECTORY}): {detail}",
+                    filepath=filepath,
+                    reason=CWSANDBOX_FILE_IS_DIRECTORY,
+                )
+            raise SandboxFileError(
+                f"Failed to read file '{filepath}' via exec-stream fallback: {detail}",
+                filepath=filepath,
+                reason=CWSANDBOX_FILE_IO_FAILED,
+            )
+        return stdout
+
+    async def _read_file_async(
+        self,
+        filepath: str,
+        timeout: float,
+    ) -> bytes:
+        """Internal async: Read a file from the sandbox filesystem."""
+        await self._ensure_started_async()
+        if self._is_done or self._is_stopping:
+            raise SandboxNotRunningError(f"Sandbox {self._sandbox_id} has been stopped")
+        if self._sandbox_id is None:
+            raise SandboxNotRunningError("No sandbox is running")
+
+        # Wait for sandbox to be running before file operations
+        await self._wait_until_running_async()
+
+        await self._ensure_client()
+        assert self._stub is not None
+
+        logger.debug("Reading file from sandbox %s: %s", self._sandbox_id, filepath)
+
+        try:
+            return await self._read_file_unary_async(filepath, timeout)
+        except SandboxResourceExhaustedError:
+            # Read fallback fires on ANY RESOURCE_EXHAUSTED (not just message-
+            # size-shaped) because the client cannot peek at remote file size
+            # before the unary attempt. This may mask backend resource-pressure
+            # classification, but it avoids relying on grpcio's brittle error
+            # text. The write fallback below is selective because the client
+            # knows the local payload size.
+            logger.debug(
+                "Falling back to exec-streaming read for sandbox %s: %s",
+                self._sandbox_id,
+                filepath,
+            )
+            return await self._read_file_via_exec_streaming(filepath, timeout)
+
     def read_file(
         self,
         filepath: str,
@@ -3821,6 +4023,90 @@ class Sandbox:
         timeout = timeout_seconds if timeout_seconds is not None else self._request_timeout_seconds
         future = self._loop_manager.run_async(self._read_file_async(filepath, timeout))
         return OperationRef(future)
+
+    async def _write_file_unary_async(
+        self,
+        filepath: str,
+        contents: bytes,
+        timeout: float,
+    ) -> None:
+        assert self._stub is not None
+        request = gateway_pb2.AddFileSandboxRequest(
+            sandbox_id=self._sandbox_id,
+            filepath=filepath,
+            file_contents=contents,
+            max_timeout_seconds=int(timeout),
+        )
+
+        try:
+            response = await self._stub.AddFile(
+                request, timeout=timeout, metadata=self._auth_metadata
+            )
+        except grpc.RpcError as e:
+            raise _translate_rpc_error(
+                e,
+                sandbox_id=self._sandbox_id,
+                operation="Write file",
+                filepath=filepath,
+            ) from e
+
+        if not response.success:
+            logger.warning("Failed to write file %s to sandbox %s", filepath, self._sandbox_id)
+            raise SandboxFileError(
+                f"Failed to write file '{filepath}'",
+                filepath=filepath,
+            )
+
+    async def _write_file_via_exec_streaming(
+        self,
+        filepath: str,
+        contents: bytes,
+        timeout: float,
+    ) -> None:
+        script = (
+            "path=$1\n"
+            "expected=$2\n"
+            'if ! cat > "$path"; then\n'
+            '  printf "%s\\n" "Failed to write input stream to $path" >&2\n'
+            "  exit 1\n"
+            "fi\n"
+            'actual=$(wc -c < "$path") || exit 1\n'
+            "set -- $actual\n"
+            "actual=$1\n"
+            'if [ "$actual" != "$expected" ]; then\n'
+            '  printf "%s\\n" "Expected $expected bytes but wrote $actual bytes; '
+            'target may be partial or truncated" >&2\n'
+            "  exit 1\n"
+            "fi\n"
+        )
+        try:
+            returncode, _, stderr = await self._exec_streaming_binary_async(
+                ["/bin/sh", "-c", script, "cwsandbox-write-file", filepath, str(len(contents))],
+                stdin=contents,
+                timeout_seconds=timeout,
+                operation="Write file",
+                filepath=filepath,
+            )
+        except Exception as e:
+            # The exec-stream write does direct-cat-to-target (no temp file +
+            # rename), so any interruption — gRPC timeout, transport error,
+            # mid-stream cancel — may leave a partially written file. Surface
+            # that to callers so they can decide whether to retry vs delete.
+            raise SandboxFileError(
+                f"Failed to write file '{filepath}' via exec-stream fallback. "
+                f"The target may be partial or truncated. Upstream error: {e!r}",
+                filepath=filepath,
+            ) from e
+        if returncode != 0:
+            detail = stderr.decode("utf-8", errors="replace").strip()
+            if not detail:
+                detail = f"fallback command exited with status {returncode}"
+            raise SandboxFileError(
+                "Failed to write file "
+                f"'{filepath}' via exec-stream fallback: {detail}. "
+                "The target may be partial or truncated.",
+                filepath=filepath,
+            )
 
     async def _write_file_async(
         self,
@@ -3848,31 +4134,33 @@ class Sandbox:
             len(contents),
         )
 
-        request = gateway_pb2.AddFileSandboxRequest(
-            sandbox_id=self._sandbox_id,
-            filepath=filepath,
-            file_contents=contents,
-            max_timeout_seconds=int(timeout),
-        )
+        if len(contents) > DEFAULT_FILE_UNARY_SAFE_LIMIT_BYTES:
+            logger.debug(
+                "Using exec-streaming write for sandbox %s: %s (%d bytes)",
+                self._sandbox_id,
+                filepath,
+                len(contents),
+            )
+            await self._write_file_via_exec_streaming(filepath, contents, timeout)
+            return
 
         try:
-            response = await self._stub.AddFile(
-                request, timeout=timeout, metadata=self._auth_metadata
+            await self._write_file_unary_async(filepath, contents, timeout)
+        except SandboxResourceExhaustedError as e:
+            # SandboxResourceExhaustedError covers both message-size limits
+            # and real backend resource pressure; we can't dispatch on type
+            # alone. grpcio's wording is the only signal that distinguishes
+            # them today.  If grpcio rewords, the fallback silently stops
+            # firing (no data corruption — just a missed retry).
+            text = str(e).lower()
+            if "message" not in text or "larger than max" not in text:
+                raise
+            logger.debug(
+                "Falling back to exec-streaming write for sandbox %s: %s",
+                self._sandbox_id,
+                filepath,
             )
-        except grpc.RpcError as e:
-            raise _translate_rpc_error(
-                e,
-                sandbox_id=self._sandbox_id,
-                operation="Write file",
-                filepath=filepath,
-            ) from e
-
-        if not response.success:
-            logger.warning("Failed to write file %s to sandbox %s", filepath, self._sandbox_id)
-            raise SandboxFileError(
-                f"Failed to write file '{filepath}'",
-                filepath=filepath,
-            )
+            await self._write_file_via_exec_streaming(filepath, contents, timeout)
 
     def write_file(
         self,

--- a/tests/integration/cwsandbox/test_sandbox.py
+++ b/tests/integration/cwsandbox/test_sandbox.py
@@ -10,13 +10,14 @@ Set CWSANDBOX_BASE_URL and CWSANDBOX_API_KEY environment variables before runnin
 
 import time
 import uuid
+from unittest.mock import patch
 
 import httpx
 import pytest
 
 from cwsandbox import NetworkOptions, ResourceOptions, Sandbox, SandboxDefaults, Session
 from cwsandbox._sandbox import SandboxStatus
-from cwsandbox.exceptions import SandboxError
+from cwsandbox.exceptions import SandboxError, SandboxResourceExhaustedError
 from tests.integration.cwsandbox.conftest import _SESSION_TAG
 
 
@@ -144,6 +145,36 @@ def test_sandbox_large_file_operations(sandbox_defaults: SandboxDefaults) -> Non
 
         sandbox.write_file(filepath, payload).result()
         content = sandbox.read_file(filepath).result()
+
+        assert content == payload
+
+
+def test_sandbox_large_file_exec_fallback(sandbox_defaults: SandboxDefaults) -> None:
+    """Round-trip a large binary payload through the exec-streaming fallback.
+
+    Forces both write and read down the fallback path so the test exercises
+    end-to-end streaming transfer of realistic file bytes, not just the
+    fallback's request shape.
+    """
+
+    async def force_read_message_size_error(
+        self: Sandbox,
+        filepath: str,
+        timeout: float,
+    ) -> bytes:
+        raise SandboxResourceExhaustedError(
+            "Read file resource exhausted: CLIENT: Received message larger than max"
+        )
+
+    with Sandbox.run(defaults=sandbox_defaults) as sandbox:
+        payload = bytes(i % 256 for i in range(20 * 1024 * 1024))
+        filepath = f"/tmp/test_fallback_file_{uuid.uuid4().hex}.bin"
+
+        with patch("cwsandbox._sandbox.DEFAULT_FILE_UNARY_SAFE_LIMIT_BYTES", 1):
+            sandbox.write_file(filepath, payload).result()
+
+        with patch.object(Sandbox, "_read_file_unary_async", force_read_message_size_error):
+            content = sandbox.read_file(filepath).result()
 
         assert content == payload
 

--- a/tests/unit/cwsandbox/test_sandbox.py
+++ b/tests/unit/cwsandbox/test_sandbox.py
@@ -16,11 +16,19 @@ import grpc.aio
 import pytest
 
 from cwsandbox import NetworkOptions, Sandbox, SandboxDefaults, Secret
-from cwsandbox._sandbox import SandboxStatus, _Running, _Starting, _Stopping, _Terminal
+from cwsandbox._sandbox import (
+    SandboxStatus,
+    _Running,
+    _Starting,
+    _Stopping,
+    _Terminal,
+)
 from cwsandbox.exceptions import (
     SandboxError,
+    SandboxFileError,
     SandboxNotFoundError,
     SandboxNotRunningError,
+    SandboxResourceExhaustedError,
 )
 
 
@@ -1244,6 +1252,258 @@ class TestSandboxFileOpErrorTranslation:
         assert exc_info.value.filepath == "/caller-requested-path"
         assert exc_info.value.reason == "CWSANDBOX_FILE_PERMISSION_DENIED"
         assert exc_info.value.metadata == {"filepath": "/backend-normalized-path"}
+
+
+class TestSandboxFileOperationFallback:
+    """Tests for large file operation exec-streaming fallback."""
+
+    def _setup_running_sandbox(self) -> Sandbox:
+        sandbox = Sandbox(command="sleep", args=["infinity"])
+        sandbox._sandbox_id = "sb-file-fallback"
+        sandbox._state = _Running(sandbox_id="sb-file-fallback")
+        sandbox._channel = MagicMock()
+        sandbox._stub = MagicMock()
+        sandbox._auth_metadata = ()
+        return sandbox
+
+    def test_write_file_below_threshold_uses_unary(self) -> None:
+        sandbox = self._setup_running_sandbox()
+        mock_write_response = MagicMock()
+        mock_write_response.success = True
+        sandbox._stub.AddFile = AsyncMock(return_value=mock_write_response)
+
+        with (
+            patch.object(sandbox, "_ensure_client", new_callable=AsyncMock),
+            patch.object(
+                sandbox, "_write_file_via_exec_streaming", new_callable=AsyncMock
+            ) as fallback,
+        ):
+            sandbox.write_file("/tmp/test.bin", b"data").result()
+
+        sandbox._stub.AddFile.assert_awaited_once()
+        fallback.assert_not_awaited()
+
+    def test_write_file_above_threshold_uses_exec_fallback_directly(self) -> None:
+        sandbox = self._setup_running_sandbox()
+        sandbox._stub.AddFile = AsyncMock()
+
+        with (
+            patch.object(sandbox, "_ensure_client", new_callable=AsyncMock),
+            patch("cwsandbox._sandbox.DEFAULT_FILE_UNARY_SAFE_LIMIT_BYTES", 1),
+            patch.object(
+                sandbox, "_write_file_via_exec_streaming", new_callable=AsyncMock
+            ) as fallback,
+        ):
+            sandbox.write_file("/tmp/test.bin", b"abc").result()
+
+        sandbox._stub.AddFile.assert_not_called()
+        fallback.assert_awaited_once()
+
+    def test_write_file_message_size_failure_falls_back(self) -> None:
+        sandbox = self._setup_running_sandbox()
+        sandbox._stub.AddFile = AsyncMock(
+            side_effect=MockRpcError(
+                grpc.StatusCode.RESOURCE_EXHAUSTED,
+                "trying to send message larger than max (5242941 vs. 4194304)",
+            )
+        )
+
+        with (
+            patch.object(sandbox, "_ensure_client", new_callable=AsyncMock),
+            patch.object(
+                sandbox, "_write_file_via_exec_streaming", new_callable=AsyncMock
+            ) as fallback,
+        ):
+            sandbox.write_file("/tmp/test.bin", b"data").result()
+
+        sandbox._stub.AddFile.assert_awaited_once()
+        fallback.assert_awaited_once()
+
+    def test_write_file_resource_pressure_does_not_fallback(self) -> None:
+        sandbox = self._setup_running_sandbox()
+        sandbox._stub.AddFile = AsyncMock(
+            side_effect=MockRpcError(grpc.StatusCode.RESOURCE_EXHAUSTED, "runner quota exceeded")
+        )
+
+        with (
+            patch.object(sandbox, "_ensure_client", new_callable=AsyncMock),
+            patch.object(
+                sandbox, "_write_file_via_exec_streaming", new_callable=AsyncMock
+            ) as fallback,
+            pytest.raises(SandboxResourceExhaustedError),
+        ):
+            sandbox.write_file("/tmp/test.bin", b"data").result()
+
+        fallback.assert_not_awaited()
+
+    def test_read_file_successful_unary_skips_fallback(self) -> None:
+        sandbox = self._setup_running_sandbox()
+        mock_read_response = MagicMock()
+        mock_read_response.success = True
+        mock_read_response.file_contents = b"file data"
+        sandbox._stub.RetrieveFile = AsyncMock(return_value=mock_read_response)
+
+        with (
+            patch.object(sandbox, "_ensure_client", new_callable=AsyncMock),
+            patch.object(
+                sandbox, "_read_file_via_exec_streaming", new_callable=AsyncMock
+            ) as fallback,
+        ):
+            data = sandbox.read_file("/tmp/test.bin").result()
+
+        assert data == b"file data"
+        sandbox._stub.RetrieveFile.assert_awaited_once()
+        fallback.assert_not_awaited()
+
+    def test_read_file_resource_exhausted_falls_back_without_message_detail(self) -> None:
+        sandbox = self._setup_running_sandbox()
+        sandbox._stub.RetrieveFile = AsyncMock(
+            side_effect=MockRpcError(
+                grpc.StatusCode.RESOURCE_EXHAUSTED,
+                "runner quota exceeded",
+            )
+        )
+
+        with (
+            patch.object(sandbox, "_ensure_client", new_callable=AsyncMock),
+            patch.object(
+                sandbox,
+                "_read_file_via_exec_streaming",
+                new_callable=AsyncMock,
+                return_value=b"\x00\xffdata",
+            ) as fallback,
+        ):
+            data = sandbox.read_file("/tmp/test.bin").result()
+
+        assert data == b"\x00\xffdata"
+        sandbox._stub.RetrieveFile.assert_awaited_once()
+        fallback.assert_awaited_once()
+
+    def test_binary_stream_exec_preserves_stdout_bytes(self) -> None:
+        from cwsandbox._proto import streaming_pb2
+
+        sandbox = self._setup_running_sandbox()
+        payload = b"\x00\xffbinary\n"
+        output = streaming_pb2.ExecStreamResponse(
+            output=streaming_pb2.ExecStreamOutput(
+                stream_type=streaming_pb2.ExecStreamOutput.STREAM_TYPE_STDOUT,
+                data=payload,
+            )
+        )
+        exit_response = streaming_pb2.ExecStreamResponse(
+            exit=streaming_pb2.ExecStreamExit(exit_code=0)
+        )
+        mock_call = MockStreamCall(responses=[output, exit_response])
+        mock_channel, mock_stub = create_mock_channel_and_stub(mock_call)
+        sandbox._streaming_channel = mock_channel
+
+        with (
+            patch.object(sandbox, "_wait_until_running_async", new_callable=AsyncMock),
+            patch(
+                "cwsandbox._sandbox.streaming_pb2_grpc.GatewayStreamingServiceStub",
+                return_value=mock_stub,
+            ),
+        ):
+            returncode, stdout, stderr = sandbox._loop_manager.run_sync(
+                sandbox._exec_streaming_binary_async(
+                    ["cat", "/tmp/test"],
+                    timeout_seconds=5.0,
+                    operation="Read file",
+                )
+            )
+
+        assert returncode == 0
+        assert stdout == payload
+        assert stderr == b""
+
+    def test_binary_stream_exec_sends_raw_stdin_once(self) -> None:
+        import asyncio
+
+        from cwsandbox._proto import streaming_pb2
+
+        sandbox = self._setup_running_sandbox()
+        payload = b"\x00\xffraw-input"
+        stdin_chunks: list[bytes] = []
+        init_commands: list[list[str]] = []
+        close_event = asyncio.Event()
+
+        def on_write(request: Any) -> None:
+            if request.HasField("init"):
+                init_commands.append(list(request.init.command))
+            elif request.HasField("stdin"):
+                stdin_chunks.append(request.stdin.data)
+            elif request.HasField("close"):
+                close_event.set()
+
+        async def response_generator() -> AsyncIterator[Any]:
+            yield streaming_pb2.ExecStreamResponse(ready=streaming_pb2.StreamingExecReady())
+            await asyncio.wait_for(close_event.wait(), timeout=5.0)
+            yield streaming_pb2.ExecStreamResponse(exit=streaming_pb2.ExecStreamExit(exit_code=0))
+
+        mock_call = MockBidirectionalStreamCall(
+            response_generator=response_generator,
+            on_write=on_write,
+        )
+        mock_channel, mock_stub = create_mock_channel_and_stub_bidirectional(mock_call)
+        sandbox._streaming_channel = mock_channel
+
+        with (
+            patch.object(sandbox, "_wait_until_running_async", new_callable=AsyncMock),
+            patch(
+                "cwsandbox._sandbox.streaming_pb2_grpc.GatewayStreamingServiceStub",
+                return_value=mock_stub,
+            ),
+        ):
+            returncode, stdout, stderr = sandbox._loop_manager.run_sync(
+                sandbox._exec_streaming_binary_async(
+                    ["/bin/sh", "-c", "cat >/tmp/test"],
+                    stdin=payload,
+                    timeout_seconds=5.0,
+                    operation="Write file",
+                )
+            )
+
+        assert returncode == 0
+        assert stdout == b""
+        assert stderr == b""
+        assert b"".join(stdin_chunks) == payload
+        assert len(mock_stub.StreamExec.call_args_list) == 1
+        assert init_commands == [["/bin/sh", "-c", "cat >/tmp/test"]]
+        assert "base64" not in " ".join(init_commands[0])
+
+    def test_read_fallback_nonzero_maps_to_file_error(self) -> None:
+        sandbox = self._setup_running_sandbox()
+
+        with patch.object(
+            sandbox,
+            "_exec_streaming_binary_async",
+            new_callable=AsyncMock,
+            return_value=(2, b"", b"File not found: /tmp/missing\n"),
+        ):
+            with pytest.raises(SandboxFileError) as exc_info:
+                sandbox._loop_manager.run_sync(
+                    sandbox._read_file_via_exec_streaming("/tmp/missing", 5.0)
+                )
+
+        assert exc_info.value.filepath == "/tmp/missing"
+        assert "File not found" in str(exc_info.value)
+
+    def test_write_fallback_nonzero_mentions_partial_target(self) -> None:
+        sandbox = self._setup_running_sandbox()
+
+        with patch.object(
+            sandbox,
+            "_exec_streaming_binary_async",
+            new_callable=AsyncMock,
+            return_value=(1, b"", b"short write\n"),
+        ):
+            with pytest.raises(SandboxFileError) as exc_info:
+                sandbox._loop_manager.run_sync(
+                    sandbox._write_file_via_exec_streaming("/tmp/out.bin", b"data", 5.0)
+                )
+
+        assert exc_info.value.filepath == "/tmp/out.bin"
+        assert "partial or truncated" in str(exc_info.value)
 
 
 class TestSandboxWaitUntilComplete:


### PR DESCRIPTION
## Summary

Raising the unary gRPC message limit fixes the old 4 MiB client mismatch, but file operations can still exceed the safe unary envelope. The SDK should keep the existing `read_file()` and `write_file()` API usable for larger payloads without requiring every caller to build its own workaround.

This change adds a transparent client-side fallback that uses one non-TTY `StreamExec` session per transfer. Writes above the safe unary threshold use the fallback directly; below the threshold, writes only fall back on a message-size-shaped `RESOURCE_EXHAUSTED` from the unary path. Reads still try unary first because the client does not know the remote file size; any translated `SandboxResourceExhaustedError` from the unary read then triggers the fallback (the read path intentionally avoids depending on grpcio's error wording).

The fallback moves raw bytes, not base64, and keeps fallback command failures mapped to `SandboxFileError` for the file-operation APIs. It preserves current direct-write semantics, so an interrupted fallback upload may leave a partial or truncated target file.

The fallback is an interim SDK-owned data path. It uses non-TTY command execution inside the sandbox and depends on POSIX-ish tools such as `/bin/sh`, `cat`, `wc`, and `test`. Extremely minimal images that lack those tools can still fail with a file-operation error.

For very large durable data, the longer-term direction will be CoreWeave AI Object Storage integration with CoreWeave-managed object interactions, which is currently a work in progress.

## Testing

- [x] `mise run check`
- [x] `uv run pytest tests/unit/cwsandbox/test_sandbox.py -k "file and fallback" -v`
- [x] `uv run pytest tests/integration/cwsandbox/test_sandbox.py::test_sandbox_large_file_operations tests/integration/cwsandbox/test_sandbox.py::test_sandbox_large_file_exec_fallback -v`
  - `test_sandbox_large_file_operations`: 5 MiB unary round-trip - regression check that the raised channel limit still holds.
  - `test_sandbox_large_file_exec_fallback`: 20 MiB binary round-trip; the unary safe-limit threshold is patched to 1 and the unary read helper is patched to raise, forcing both write and read down the exec-streaming fallback.
