### PR TITLE
feat(session): add release API

### DIFF
--- a/src/cwsandbox/_session.py
+++ b/src/cwsandbox/_session.py
@@ -644,6 +644,39 @@ class Session:
         self._register_sandbox(sandbox)
         sandbox._session = self
 
+    def release(self, sandbox: Sandbox) -> Sandbox:
+        """Release a sandbox from this session without stopping it.
+
+        This is the inverse of :meth:`adopt`: the sandbox is no longer tracked
+        for automatic cleanup, so ``Session.close()`` and process-exit cleanup
+        will not stop the remote sandbox. The caller remains responsible for
+        stopping or deleting the sandbox later.
+
+        Args:
+            sandbox: A Sandbox instance to stop managing.
+
+        Returns:
+            The released sandbox, for chaining.
+
+        Examples:
+            ```python
+            with Session(defaults) as session:
+                sb = session.sandbox()
+                sb.start().result()
+                session.release(sb)
+
+            # The released sandbox keeps running and must be stopped explicitly.
+            try:
+                sb.exec(["echo", "still running"]).result()
+            finally:
+                sb.stop(missing_ok=True).result()
+            ```
+        """
+        self._deregister_sandbox(sandbox)
+        if sandbox._session is self:
+            sandbox._session = None
+        return sandbox
+
     def function(
         self,
         *,

--- a/tests/unit/cwsandbox/test_session.py
+++ b/tests/unit/cwsandbox/test_session.py
@@ -941,6 +941,57 @@ class TestSessionAdopt:
             session.adopt(sandbox)
 
 
+class TestSessionRelease:
+    """Tests for Session.release method."""
+
+    def test_release_unregisters_sandbox(self) -> None:
+        """Test release() removes sandbox from session cleanup tracking."""
+        session = Session()
+        sandbox = session.sandbox(command="sleep", args=["infinity"])
+
+        released = session.release(sandbox)
+
+        assert released is sandbox
+        assert session.sandbox_count == 0
+        assert sandbox._session is None
+
+    @pytest.mark.asyncio
+    async def test_close_does_not_stop_released_sandbox(self) -> None:
+        """Test session.close() does not stop released sandboxes."""
+        session = Session()
+        sandbox = session.sandbox(command="sleep", args=["infinity"])
+
+        with patch.object(sandbox, "_stop_async", new_callable=AsyncMock) as mock_stop:
+            session.release(sandbox)
+            await session._close_async()
+
+        mock_stop.assert_not_called()
+
+    def test_release_is_idempotent_for_untracked_sandbox(self) -> None:
+        """Test release() is safe for sandboxes not tracked by the session."""
+        session = Session()
+        sandbox = Sandbox(command="sleep", args=["infinity"])
+
+        released = session.release(sandbox)
+
+        assert released is sandbox
+        assert session.sandbox_count == 0
+        assert sandbox._session is None
+
+    def test_release_does_not_clear_other_session_owner(self) -> None:
+        """Test release() does not detach sandboxes owned by another session."""
+        session = Session()
+        other_session = Session()
+        sandbox = other_session.sandbox(command="sleep", args=["infinity"])
+
+        released = session.release(sandbox)
+
+        assert released is sandbox
+        assert session.sandbox_count == 0
+        assert other_session.sandbox_count == 1
+        assert sandbox._session is other_session
+
+
 class TestSessionReportTo:
     """Tests for Session report_to parameter."""
 


### PR DESCRIPTION
## Summary
- Add `Session.release(sandbox)` as the public inverse of `Session.adopt(...)`.
- Allow callers to remove a sandbox from session cleanup without stopping the remote sandbox.
- Cover release behavior, idempotency, session-close behavior, and ownership preservation across sessions.