### PR TITLE
fix: include file path in file errors

### DIFF
--- a/src/cwsandbox/_sandbox.py
+++ b/src/cwsandbox/_sandbox.py
@@ -591,8 +591,11 @@ def _translate_rpc_error(
             effective_filepath = (
                 filepath if filepath is not None else parsed_metadata.get("filepath")
             )
+            filepath_context = (
+                f" for {effective_filepath!r}" if effective_filepath is not None else ""
+            )
             return SandboxFileError(
-                f"File operation failed ({reason}): {details}",
+                f"File operation failed{filepath_context} ({reason}): {details}",
                 filepath=effective_filepath,
                 reason=reason,
                 metadata=metadata,

--- a/tests/unit/cwsandbox/test_sandbox.py
+++ b/tests/unit/cwsandbox/test_sandbox.py
@@ -1231,6 +1231,8 @@ class TestSandboxFileOpErrorTranslation:
 
         assert exc_info.value.filepath == "/caller-requested-path"
         assert exc_info.value.reason == "CWSANDBOX_FILE_NOT_FOUND"
+        assert "/caller-requested-path" in str(exc_info.value)
+        assert "CWSANDBOX_FILE_NOT_FOUND" in str(exc_info.value)
         # Backend metadata still round-trips so callers can inspect it.
         assert exc_info.value.metadata == {"filepath": "/backend-normalized-path"}
 


### PR DESCRIPTION
## Description

Returns the file path in the error message when a file operation fails

## Testing

Updated unit tests and ran the following script:

```
from wandb.sandbox import Sandbox
import wandb

wandb.login()

with Sandbox.run(
    "sh",
    "-c",
    "sleep 60",
    container_image="python:3.11-slim",
    max_lifetime_seconds=120,
) as sb:
    print("sandbox_id", sb.sandbox_id)
    sb.wait(timeout=120)
    sb.read_file("/tmp/sandbox-e2e-missing-file.txt").result(timeout=60)
```

Before (only `File operation failed` displayed to the user):

```
uv run python missing_file_repro.py
wandb: [wandb.login()] Loaded credentials for https://api.wandb.ai from /Users/nicholaspun/.netrc.
wandb: Currently logged in as: nicholas-pun (wandb) to https://api.wandb.ai. Use `wandb login --relogin` to force relogin
sandbox_id b4be58e0-6257-4ce4-80be-689256bff5c8
Traceback (most recent call last):
  File "/Users/nicholaspun/Documents/test-wb-sandbox/.venv/lib/python3.11/site-packages/cwsandbox/_sandbox.py", line 3773, in _read_file_async
    response = await self._stub.RetrieveFile(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ...
    raise _translate_rpc_error(
cwsandbox.exceptions.SandboxFileError: File operation failed (CWSANDBOX_FILE_NOT_FOUND): peer Gateway returned RetrieveFile error: peer RetrieveFile returned error: rpc error: code = NotFound desc = 
```

After (`File operation failed for '/tmp/sandbox-e2e-missing-file.txt'` surfaced):

```
PYTHONPATH=/Users/nicholaspun/Documents/cwsandbox-client/src uv run python missing_file_repro.py
wandb: [wandb.login()] Loaded credentials for https://api.wandb.ai from /Users/nicholaspun/.netrc.
wandb: Currently logged in as: nicholas-pun (wandb) to https://api.wandb.ai. Use `wandb login --relogin` to force relogin
sandbox_id 3ca54f50-c94b-4e19-a8b4-d4fb9459bc3f
Traceback (most recent call last):
  File "/Users/nicholaspun/Documents/cwsandbox-client/src/cwsandbox/_sandbox.py", line 3905, in _read_file_unary_async
    response = await self._stub.RetrieveFile(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ...
  File "/Users/nicholaspun/Documents/cwsandbox-client/src/cwsandbox/_sandbox.py", line 3909, in _read_file_unary_async
    raise _translate_rpc_error(
cwsandbox.exceptions.SandboxFileError: File operation failed for '/tmp/sandbox-e2e-missing-file.txt' (CWSANDBOX_FILE_NOT_FOUND): peer Gateway returned RetrieveFile error: peer RetrieveFile returned error: rpc error: code = NotFound desc = 
```