### PR TITLE
fix: skip signal handlers outside main thread (#136)

### DIFF
--- a/src/cwsandbox/_cleanup.py
+++ b/src/cwsandbox/_cleanup.py
@@ -17,6 +17,7 @@ import atexit
 import logging
 import signal
 import sys
+import threading
 from collections.abc import Callable
 from types import FrameType
 
@@ -30,6 +31,7 @@ _cleanup_in_progress: bool = False
 _original_sigint: _SignalHandler = None
 _original_sigterm: _SignalHandler = None
 _handlers_installed: bool = False
+_atexit_registered: bool = False
 
 
 def _cleanup() -> None:
@@ -94,13 +96,18 @@ def _install_handlers() -> None:
 
     The original signal handlers are preserved and chained after cleanup.
     """
-    global _original_sigint, _original_sigterm, _handlers_installed
+    global _original_sigint, _original_sigterm, _handlers_installed, _atexit_registered
+
+    if not _atexit_registered:
+        atexit.register(_cleanup)
+        _atexit_registered = True
 
     if _handlers_installed:
         return
 
-    # Register atexit handler
-    atexit.register(_cleanup)
+    if threading.current_thread() is not threading.main_thread():
+        logger.debug("Skipping signal handlers outside the main thread")
+        return
 
     # Install signal handlers, preserving originals for chaining
     _original_sigint = signal.signal(signal.SIGINT, _signal_handler)
@@ -116,11 +123,12 @@ def _reset_for_testing() -> None:
     This function is intended for use in tests only. It resets the
     module-level state to allow handlers to be reinstalled.
     """
-    global _cleanup_in_progress, _handlers_installed
+    global _cleanup_in_progress, _handlers_installed, _atexit_registered
     global _original_sigint, _original_sigterm
 
     _cleanup_in_progress = False
     _handlers_installed = False
+    _atexit_registered = False
 
     # Restore original handlers if they were saved
     if _original_sigint is not None:

--- a/tests/unit/cwsandbox/test_cleanup.py
+++ b/tests/unit/cwsandbox/test_cleanup.py
@@ -5,6 +5,7 @@
 """Unit tests for cwsandbox._cleanup module."""
 
 import signal
+import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -197,6 +198,40 @@ class TestInstallHandlers:
 
                 # Should only register once
                 assert mock_register.call_count == 1
+
+    def test_install_handlers_skips_signals_outside_main_thread(self) -> None:
+        """Test importing from a worker thread does not install signal handlers."""
+        errors = []
+
+        with patch("cwsandbox._cleanup.atexit.register") as mock_register:
+            with patch("cwsandbox._cleanup.signal.signal") as mock_signal:
+
+                def install_in_thread() -> None:
+                    try:
+                        _install_handlers()
+                    except Exception as exc:  # pragma: no cover - assertion below fails
+                        errors.append(exc)
+
+                thread = threading.Thread(target=install_in_thread)
+                thread.start()
+                thread.join()
+
+                assert errors == []
+                mock_register.assert_called_once_with(_cleanup)
+                mock_signal.assert_not_called()
+
+    def test_install_handlers_can_install_signals_after_worker_thread_import(self) -> None:
+        """Test signal handlers can still be installed later from the main thread."""
+        with patch("cwsandbox._cleanup.atexit.register") as mock_register:
+            with patch("cwsandbox._cleanup.signal.signal") as mock_signal:
+                thread = threading.Thread(target=_install_handlers)
+                thread.start()
+                thread.join()
+
+                _install_handlers()
+
+                mock_register.assert_called_once_with(_cleanup)
+                assert mock_signal.call_count == 2
 
     def test_install_handlers_preserves_original_handlers(self) -> None:
         """Test _install_handlers preserves original signal handlers."""


### PR DESCRIPTION
Closes #136

## Summary

Importing `cwsandbox` from a worker thread currently fails because `_cleanup.py` installs SIGINT/SIGTERM handlers at import time, and `signal.signal()` is only valid in the main thread.

This keeps the `atexit` cleanup registration available from any thread, but skips installing signal handlers when `_install_handlers()` runs outside the main thread. If the module is later initialized from the main thread, the signal handlers can still be installed.

## Verification

- Added unit coverage for worker-thread handler installation.
- Confirmed a worker-thread import of `cwsandbox._cleanup` no longer raises `ValueError`.
- Ran `pytest tests/unit/cwsandbox/test_cleanup.py -q`: 18 passed.
- Ran `python -m ruff check src/cwsandbox/_cleanup.py tests/unit/cwsandbox/test_cleanup.py`: all checks passed.
