### PR TITLE
chore: add djenriquez and brandonrjacobs as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owners for everything in the repo
-*       @coreweave/applied-aviato
+*       @coreweave/applied-aviato @djenriquez @brandonrjacobs


### PR DESCRIPTION
## Summary
Adds @djenriquez and @brandonrjacobs as codeowners alongside the existing `@coreweave/applied-aviato` team for all files in the repo.

## Changes
- `.github/CODEOWNERS`: append `@djenriquez @brandonrjacobs` to the default `*` rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)