### PR TITLE
fix: send init-only request stream in read_file_streaming

### DIFF
--- a/src/cwsandbox/_sandbox.py
+++ b/src/cwsandbox/_sandbox.py
@@ -6179,14 +6179,17 @@ class Sandbox:
             total_bytes = 0
 
             async def request_generator() -> AsyncIterator[streaming_pb2.ExecStreamRequest]:
+                # Init only — no stdin frames and no explicit close. The command
+                # reads the file from its argument, never stdin, so an early
+                # stdin close is unnecessary and can race server-side stream
+                # setup. The request stream half-closes when this generator
+                # returns, matching the stdin-less exec path.
                 yield streaming_pb2.ExecStreamRequest(
                     init=streaming_pb2.ExecStreamInit(
                         sandbox_id=sandbox_id,
                         command=["/bin/cat", "--", filepath],
                     )
                 )
-                # Close stdin immediately so cat reads the file and exits.
-                yield streaming_pb2.ExecStreamRequest(close=streaming_pb2.ExecStreamClose())
 
             # The read gets the budget remaining after the pre-read stat, so the
             # two phases together honor the caller's overall timeout.

--- a/tests/unit/cwsandbox/test_sandbox.py
+++ b/tests/unit/cwsandbox/test_sandbox.py
@@ -2196,6 +2196,31 @@ class TestSandboxReadFileStreaming:
 
         assert chunks == [b"hello ", b"world"]
 
+    def test_sends_init_only_no_stdin_close(self) -> None:
+        """The request stream must carry only the init frame.
+
+        The read command never consumes stdin, so no stdin close frame is
+        needed; sending one early can race server-side stream setup.
+        """
+        sandbox = self._setup_running_sandbox()
+        responses = [
+            self._output(b"payload"),
+            self._exit(0),
+        ]
+        mock_call, mock_channel, mock_stub = self._drive(sandbox, responses)
+
+        with contextlib.ExitStack() as stack:
+            for p in self._patches(sandbox, mock_channel, mock_stub):
+                stack.enter_context(p)
+
+            reader = sandbox.read_file_streaming("/tmp/hello.txt")
+            chunks = list(reader)
+
+        assert chunks == [b"payload"]
+        assert len(mock_call._writes) == 1
+        assert mock_call._writes[0].HasField("init")
+        assert not any(req.HasField("close") for req in mock_call._writes)
+
     def test_nonzero_exit_surfaces_stderr_detail(self) -> None:
         from cwsandbox.exceptions import SandboxFileError
 


### PR DESCRIPTION
## Problem

`read_file_streaming` sent a stdin-close frame immediately after the init frame on the exec stream. The streamed read command never consumes stdin, and the early close frame can race server-side stream setup. When it does, the transfer intermittently fails after the first chunk with:

```
SandboxFileError: Failed to stream-read file '...': stream-read command exited with status 137
```

The failure is independent of file size and strikes roughly 1 in 3 calls.

## Fix

Send only the init frame. The request stream half-closes when the generator returns, which is exactly how the stdin-less exec path (used by the `read_file` large-file fallback) already behaves — that path has never exhibited the failure.

## Testing

- New regression test asserts the request stream carries exactly the init frame and no stdin-close frame.
- Full unit suite passes (1249 tests).
- Verified against production: 8/8 repeated 40 MiB `read_file_streaming` reads passed with this change (including transfers slower than the previous failure threshold), where the unpatched client failed ~1 in 3.