### PR TITLE
feat(cli): add delete command

### DIFF
--- a/src/cwsandbox/cli/__init__.py
+++ b/src/cwsandbox/cli/__init__.py
@@ -23,6 +23,7 @@ except ModuleNotFoundError as e:
         ) from e
     raise
 
+from cwsandbox.cli.delete import delete_sandbox
 from cwsandbox.cli.exec import exec_command
 from cwsandbox.cli.get import get_sandbox
 from cwsandbox.cli.list import list_sandboxes
@@ -53,6 +54,7 @@ def cli() -> None:
 
 cli.add_command(list_sandboxes, "ls")
 cli.add_command(get_sandbox, "get")
+cli.add_command(delete_sandbox, "delete")
 cli.add_command(exec_command, "exec")
 cli.add_command(logs, "logs")
 cli.add_command(shell, "sh")

--- a/src/cwsandbox/cli/delete.py
+++ b/src/cwsandbox/cli/delete.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2025 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: cwsandbox-client
+
+"""cwsandbox delete - delete a sandbox."""
+
+from __future__ import annotations
+
+import click
+
+from cwsandbox import Sandbox
+
+
+@click.command("delete")
+@click.argument("sandbox_id")
+@click.option(
+    "--missing-ok",
+    is_flag=True,
+    default=False,
+    help="Do not fail if the sandbox is already missing.",
+)
+@click.option(
+    "--timeout",
+    "-t",
+    "timeout_seconds",
+    type=click.FloatRange(min=0, min_open=True),
+    default=None,
+    help="Timeout in seconds.",
+)
+@click.option("--quiet", "-q", is_flag=True, default=False, help="Suppress success output.")
+def delete_sandbox(
+    sandbox_id: str,
+    missing_ok: bool,
+    timeout_seconds: float | None,
+    quiet: bool,
+) -> None:
+    """Delete a sandbox.
+
+    SANDBOX_ID is the ID of the sandbox to delete.
+    """
+    Sandbox.delete(
+        sandbox_id,
+        missing_ok=missing_ok,
+        timeout_seconds=timeout_seconds,
+    ).result()
+    if not quiet:
+        click.echo(f"Deleted sandbox {sandbox_id}.")

--- a/tests/unit/cwsandbox/test_cli_delete.py
+++ b/tests/unit/cwsandbox/test_cli_delete.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: 2025 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: cwsandbox-client
+
+"""Tests for cwsandbox delete CLI command."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from cwsandbox.cli import cli
+from cwsandbox.exceptions import SandboxNotFoundError
+from tests.unit.cwsandbox.conftest import make_operation_ref
+
+
+class TestDeleteCommand:
+    """Tests for the cwsandbox delete CLI command."""
+
+    def test_delete_registered(self) -> None:
+        """Delete command is registered on the CLI group."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["delete", "--help"])
+        assert result.exit_code == 0
+        assert "SANDBOX_ID" in result.output
+
+    def test_delete_sandbox(self) -> None:
+        """cwsandbox delete deletes a sandbox and prints confirmation."""
+        with patch("cwsandbox.cli.delete.Sandbox") as mock_sandbox_cls:
+            mock_sandbox_cls.delete.return_value = make_operation_ref(None)
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ["delete", "abc-123"])
+
+        assert result.exit_code == 0
+        assert "Deleted sandbox abc-123." in result.output
+        mock_sandbox_cls.delete.assert_called_once_with(
+            "abc-123",
+            missing_ok=False,
+            timeout_seconds=None,
+        )
+
+    def test_delete_with_options(self) -> None:
+        """cwsandbox delete passes --missing-ok, --timeout, and --quiet correctly."""
+        with patch("cwsandbox.cli.delete.Sandbox") as mock_sandbox_cls:
+            mock_sandbox_cls.delete.return_value = make_operation_ref(None)
+
+            runner = CliRunner()
+            result = runner.invoke(
+                cli, ["delete", "abc-123", "--missing-ok", "--timeout", "5", "--quiet"]
+            )
+
+        assert result.exit_code == 0
+        assert result.output == ""
+        mock_sandbox_cls.delete.assert_called_once_with(
+            "abc-123",
+            missing_ok=True,
+            timeout_seconds=5.0,
+        )
+
+    def test_delete_sandbox_not_found(self) -> None:
+        """cwsandbox delete shows clean error for SandboxNotFoundError."""
+        mock_op_ref = MagicMock()
+        mock_op_ref.result.side_effect = SandboxNotFoundError("not found", sandbox_id="bad-id")
+
+        with patch("cwsandbox.cli.delete.Sandbox") as mock_sandbox_cls:
+            mock_sandbox_cls.delete.return_value = mock_op_ref
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ["delete", "bad-id"])
+
+        assert result.exit_code == 1
+        assert "not found" in result.output


### PR DESCRIPTION
## Summary
- add `cwsandbox delete <sandbox-id>` for deleting a sandbox by ID
- support `--missing-ok`, `--timeout`, and `--quiet`
- add unit coverage for registration, options, and not-found errors

## Tests
- `uv run pytest tests/unit/cwsandbox/test_cli_delete.py tests/unit/cwsandbox/test_cli_main.py`