### PR TITLE
feat(cli): add get command

### DIFF
--- a/src/cwsandbox/cli/__init__.py
+++ b/src/cwsandbox/cli/__init__.py
@@ -24,6 +24,7 @@ except ModuleNotFoundError as e:
     raise
 
 from cwsandbox.cli.exec import exec_command
+from cwsandbox.cli.get import get_sandbox
 from cwsandbox.cli.list import list_sandboxes
 from cwsandbox.cli.logs import logs
 from cwsandbox.cli.shell import shell
@@ -51,6 +52,7 @@ def cli() -> None:
 
 
 cli.add_command(list_sandboxes, "ls")
+cli.add_command(get_sandbox, "get")
 cli.add_command(exec_command, "exec")
 cli.add_command(logs, "logs")
 cli.add_command(shell, "sh")

--- a/src/cwsandbox/cli/get.py
+++ b/src/cwsandbox/cli/get.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: 2025 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: cwsandbox-client
+
+"""cwsandbox get - show sandbox details."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import click
+
+from cwsandbox import Sandbox
+
+
+def _sandbox_details(sandbox: Sandbox) -> dict[str, Any]:
+    """Return the CLI detail payload for a sandbox."""
+    return {
+        "sandbox_id": sandbox.sandbox_id,
+        "status": sandbox.status.value if sandbox.status else None,
+        "runner_id": sandbox.runner_id,
+        "runner_group_id": sandbox.runner_group_id,
+        "started_at": sandbox.started_at.isoformat() if sandbox.started_at else None,
+        "returncode": sandbox.returncode,
+    }
+
+
+def _display_value(value: Any) -> str:
+    if value is None:
+        return "-"
+    return str(value)
+
+
+@click.command("get")
+@click.argument("sandbox_id")
+@click.option(
+    "--output",
+    "-o",
+    "output_format",
+    default="table",
+    type=click.Choice(["table", "json"], case_sensitive=False),
+    help="Output format.",
+)
+def get_sandbox(sandbox_id: str, output_format: str) -> None:
+    """Show details for a sandbox.
+
+    SANDBOX_ID is the ID of the sandbox to inspect.
+    """
+    sandbox = Sandbox.from_id(sandbox_id).result()
+    details = _sandbox_details(sandbox)
+
+    if output_format == "json":
+        click.echo(json.dumps(details, indent=2))
+        return
+
+    started = sandbox.started_at.strftime("%Y-%m-%d %H:%M:%S UTC") if sandbox.started_at else None
+    rows = [
+        ("SANDBOX ID", details["sandbox_id"]),
+        ("STATUS", details["status"]),
+        ("RUNNER ID", details["runner_id"]),
+        ("RUNNER GROUP ID", details["runner_group_id"]),
+        ("STARTED AT", started),
+        ("RETURNCODE", details["returncode"]),
+    ]
+    width = max(len(label) for label, _ in rows)
+    for label, value in rows:
+        click.echo(f"{label:<{width}}  {_display_value(value)}")

--- a/tests/unit/cwsandbox/test_cli_get.py
+++ b/tests/unit/cwsandbox/test_cli_get.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: 2025 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: cwsandbox-client
+
+"""Tests for cwsandbox get CLI command."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from cwsandbox.cli import cli
+from cwsandbox.exceptions import SandboxNotFoundError
+from tests.unit.cwsandbox.conftest import make_operation_ref
+
+
+def _mock_sandbox() -> MagicMock:
+    sandbox = MagicMock()
+    sandbox.sandbox_id = "abc-123"
+    sandbox.status.value = "running"
+    sandbox.runner_id = "runner-1"
+    sandbox.runner_group_id = "group-1"
+    sandbox.started_at = datetime(2026, 1, 15, 10, 30, 0, tzinfo=UTC)
+    sandbox.returncode = None
+    return sandbox
+
+
+class TestGetCommand:
+    """Tests for the cwsandbox get CLI command."""
+
+    def test_get_registered(self) -> None:
+        """Get command is registered on the CLI group."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["get", "--help"])
+        assert result.exit_code == 0
+        assert "SANDBOX_ID" in result.output
+
+    def test_get_displays_sandbox_details(self) -> None:
+        """cwsandbox get displays sandbox details."""
+        mock_sandbox = _mock_sandbox()
+
+        with patch("cwsandbox.cli.get.Sandbox") as mock_sandbox_cls:
+            mock_sandbox_cls.from_id.return_value = make_operation_ref(mock_sandbox)
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ["get", "abc-123"])
+
+        assert result.exit_code == 0
+        assert "SANDBOX ID" in result.output
+        assert "abc-123" in result.output
+        assert "running" in result.output
+        assert "runner-1" in result.output
+        assert "2026-01-15 10:30:00 UTC" in result.output
+        mock_sandbox_cls.from_id.assert_called_once_with("abc-123")
+
+    def test_get_output_json(self) -> None:
+        """cwsandbox get --output json emits valid JSON with expected fields."""
+        mock_sandbox = _mock_sandbox()
+        mock_sandbox.status.value = "completed"
+        mock_sandbox.returncode = 0
+
+        with patch("cwsandbox.cli.get.Sandbox") as mock_sandbox_cls:
+            mock_sandbox_cls.from_id.return_value = make_operation_ref(mock_sandbox)
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ["get", "abc-123", "--output", "json"])
+
+        assert result.exit_code == 0
+        expected = json.dumps(
+            {
+                "sandbox_id": "abc-123",
+                "status": "completed",
+                "runner_id": "runner-1",
+                "runner_group_id": "group-1",
+                "started_at": "2026-01-15T10:30:00+00:00",
+                "returncode": 0,
+            },
+            indent=2,
+        )
+        assert result.output.strip() == expected
+
+    def test_get_sandbox_not_found(self) -> None:
+        """cwsandbox get shows clean error for SandboxNotFoundError."""
+        mock_op_ref = MagicMock()
+        mock_op_ref.result.side_effect = SandboxNotFoundError("not found", sandbox_id="bad-id")
+
+        with patch("cwsandbox.cli.get.Sandbox") as mock_sandbox_cls:
+            mock_sandbox_cls.from_id.return_value = mock_op_ref
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ["get", "bad-id"])
+
+        assert result.exit_code == 1
+        assert "not found" in result.output


### PR DESCRIPTION
## Summary
- add `cwsandbox get <sandbox-id>` for inspecting one sandbox
- support table and JSON output
- add unit coverage for registration, output, and not-found errors

## Tests
- `uv run pytest tests/unit/cwsandbox/test_cli_get.py tests/unit/cwsandbox/test_cli_main.py`