### PR TITLE
feat(cli): add files commands

### DIFF
--- a/src/cwsandbox/_sandbox.py
+++ b/src/cwsandbox/_sandbox.py
@@ -1967,6 +1967,8 @@ class Sandbox:
         sandbox._auth_metadata = ()
         sandbox._streaming_channel = None
         sandbox._streaming_channel_lock = asyncio.Lock()
+        sandbox._observed_file_op_cap_bytes = None
+        sandbox._streaming_fallback_warned = False
         sandbox._session = None
         sandbox._defaults = SandboxDefaults()
         sandbox._start_kwargs = {}

--- a/src/cwsandbox/cli/__init__.py
+++ b/src/cwsandbox/cli/__init__.py
@@ -24,6 +24,7 @@ except ModuleNotFoundError as e:
     raise
 
 from cwsandbox.cli.exec import exec_command
+from cwsandbox.cli.files import files
 from cwsandbox.cli.get import get_sandbox
 from cwsandbox.cli.list import list_sandboxes
 from cwsandbox.cli.logs import logs
@@ -54,5 +55,6 @@ def cli() -> None:
 cli.add_command(list_sandboxes, "ls")
 cli.add_command(get_sandbox, "get")
 cli.add_command(exec_command, "exec")
+cli.add_command(files, "files")
 cli.add_command(logs, "logs")
 cli.add_command(shell, "sh")

--- a/src/cwsandbox/cli/files.py
+++ b/src/cwsandbox/cli/files.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: 2025 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: cwsandbox-client
+
+"""cwsandbox files - read and write sandbox files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from cwsandbox import Sandbox
+
+
+@click.group()
+def files() -> None:
+    """Read and write files in a sandbox."""
+
+
+@files.command("read")
+@click.argument("sandbox_id")
+@click.argument("remote_path")
+@click.option(
+    "--output",
+    "-o",
+    "output_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Write output to a local file instead of stdout.",
+)
+@click.option(
+    "--timeout",
+    "-t",
+    "timeout_seconds",
+    type=click.FloatRange(min=0, min_open=True),
+    default=None,
+    help="Timeout in seconds.",
+)
+def read_file(
+    sandbox_id: str, remote_path: str, output_path: Path | None, timeout_seconds: float | None
+) -> None:
+    """Read a file from a sandbox.
+
+    SANDBOX_ID is the ID of the sandbox to read from.
+    REMOTE_PATH is the file path inside the sandbox.
+    """
+    sandbox = Sandbox.from_id(sandbox_id).result()
+    data = sandbox.read_file(remote_path, timeout_seconds=timeout_seconds).result()
+
+    if output_path is not None:
+        output_path.write_bytes(data)
+        return
+
+    try:
+        click.get_binary_stream("stdout").write(data)
+    except BrokenPipeError:
+        pass
+
+
+@files.command("write")
+@click.argument("sandbox_id")
+@click.argument("remote_path")
+@click.argument(
+    "local_path",
+    type=click.Path(exists=True, dir_okay=False, readable=True, path_type=Path),
+)
+@click.option(
+    "--timeout",
+    "-t",
+    "timeout_seconds",
+    type=click.FloatRange(min=0, min_open=True),
+    default=None,
+    help="Timeout in seconds.",
+)
+@click.option("--quiet", "-q", is_flag=True, default=False, help="Suppress success output.")
+def write_file(
+    sandbox_id: str,
+    remote_path: str,
+    local_path: Path,
+    timeout_seconds: float | None,
+    quiet: bool,
+) -> None:
+    """Write a local file into a sandbox.
+
+    SANDBOX_ID is the ID of the sandbox to write to.
+    REMOTE_PATH is the destination path inside the sandbox.
+    LOCAL_PATH is the local file to upload.
+    """
+    data = local_path.read_bytes()
+    sandbox = Sandbox.from_id(sandbox_id).result()
+    sandbox.write_file(remote_path, data, timeout_seconds=timeout_seconds).result()
+
+    if not quiet:
+        click.echo(f"Wrote {len(data)} bytes to {remote_path}.")

--- a/tests/unit/cwsandbox/test_cli_files.py
+++ b/tests/unit/cwsandbox/test_cli_files.py
@@ -1,0 +1,169 @@
+# SPDX-FileCopyrightText: 2025 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: cwsandbox-client
+
+"""Tests for cwsandbox files CLI commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from cwsandbox.cli import cli
+from cwsandbox.exceptions import SandboxFileError, SandboxNotFoundError
+from tests.unit.cwsandbox.conftest import make_operation_ref
+
+
+def _patch_sandbox(mock_sandbox: MagicMock):
+    """Patch Sandbox.from_id for files CLI tests."""
+    return patch(
+        "cwsandbox.cli.files.Sandbox",
+        **{"from_id.return_value": make_operation_ref(mock_sandbox)},
+    )
+
+
+class TestFilesCommand:
+    """Tests for the cwsandbox files command group."""
+
+    def test_files_registered(self) -> None:
+        """Files command group is registered on the CLI group."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["files", "--help"])
+        assert result.exit_code == 0
+        assert "read" in result.output
+        assert "write" in result.output
+
+    def test_files_read_prints_stdout(self) -> None:
+        """cwsandbox files read writes file bytes to stdout."""
+        mock_sandbox = MagicMock()
+        mock_sandbox.read_file.return_value = make_operation_ref(b"hello\n")
+
+        with _patch_sandbox(mock_sandbox):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["files", "read", "sb-1", "/tmp/data.txt"])
+
+        assert result.exit_code == 0
+        assert result.output == "hello\n"
+        mock_sandbox.read_file.assert_called_once_with(
+            "/tmp/data.txt",
+            timeout_seconds=None,
+        )
+
+    def test_files_read_writes_output_file(self, tmp_path: Path) -> None:
+        """cwsandbox files read --output writes file bytes to a local file."""
+        output_path = tmp_path / "data.bin"
+        mock_sandbox = MagicMock()
+        mock_sandbox.read_file.return_value = make_operation_ref(b"\x00hello")
+
+        with _patch_sandbox(mock_sandbox):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli, ["files", "read", "sb-1", "/tmp/data.bin", "--output", str(output_path)]
+            )
+
+        assert result.exit_code == 0
+        assert result.output == ""
+        assert output_path.read_bytes() == b"\x00hello"
+
+    def test_files_read_with_timeout(self) -> None:
+        """cwsandbox files read --timeout passes timeout_seconds."""
+        mock_sandbox = MagicMock()
+        mock_sandbox.read_file.return_value = make_operation_ref(b"")
+
+        with _patch_sandbox(mock_sandbox):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli, ["files", "read", "sb-1", "/tmp/data.txt", "--timeout", "5"]
+            )
+
+        assert result.exit_code == 0
+        mock_sandbox.read_file.assert_called_once_with(
+            "/tmp/data.txt",
+            timeout_seconds=5.0,
+        )
+
+    def test_files_write_uploads_local_file(self, tmp_path: Path) -> None:
+        """cwsandbox files write reads a local file and writes it to the sandbox."""
+        local_path = tmp_path / "data.txt"
+        local_path.write_bytes(b"hello\n")
+        mock_sandbox = MagicMock()
+        mock_sandbox.write_file.return_value = make_operation_ref(None)
+
+        with _patch_sandbox(mock_sandbox):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli, ["files", "write", "sb-1", "/tmp/data.txt", str(local_path)]
+            )
+
+        assert result.exit_code == 0
+        assert "Wrote 6 bytes to /tmp/data.txt." in result.output
+        mock_sandbox.write_file.assert_called_once_with(
+            "/tmp/data.txt",
+            b"hello\n",
+            timeout_seconds=None,
+        )
+
+    def test_files_write_with_options(self, tmp_path: Path) -> None:
+        """cwsandbox files write passes --timeout and honors --quiet."""
+        local_path = tmp_path / "data.txt"
+        local_path.write_bytes(b"hello")
+        mock_sandbox = MagicMock()
+        mock_sandbox.write_file.return_value = make_operation_ref(None)
+
+        with _patch_sandbox(mock_sandbox):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                [
+                    "files",
+                    "write",
+                    "sb-1",
+                    "/tmp/data.txt",
+                    str(local_path),
+                    "--timeout",
+                    "7",
+                    "--quiet",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert result.output == ""
+        mock_sandbox.write_file.assert_called_once_with(
+            "/tmp/data.txt",
+            b"hello",
+            timeout_seconds=7.0,
+        )
+
+    def test_files_read_sandbox_not_found(self) -> None:
+        """cwsandbox files read shows clean errors for SandboxNotFoundError."""
+        mock_op_ref = MagicMock()
+        mock_op_ref.result.side_effect = SandboxNotFoundError("not found", sandbox_id="bad-id")
+
+        with patch("cwsandbox.cli.files.Sandbox") as mock_sandbox_cls:
+            mock_sandbox_cls.from_id.return_value = mock_op_ref
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ["files", "read", "bad-id", "/tmp/data.txt"])
+
+        assert result.exit_code == 1
+        assert "not found" in result.output
+
+    def test_files_write_file_error(self, tmp_path: Path) -> None:
+        """cwsandbox files write shows clean errors for SandboxFileError."""
+        local_path = tmp_path / "data.txt"
+        local_path.write_bytes(b"hello")
+        mock_sandbox = MagicMock()
+        mock_op_ref = MagicMock()
+        mock_op_ref.result.side_effect = SandboxFileError("write failed", filepath="/tmp/data.txt")
+        mock_sandbox.write_file.return_value = mock_op_ref
+
+        with _patch_sandbox(mock_sandbox):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli, ["files", "write", "sb-1", "/tmp/data.txt", str(local_path)]
+            )
+
+        assert result.exit_code == 1
+        assert "write failed" in result.output

--- a/tests/unit/cwsandbox/test_sandbox.py
+++ b/tests/unit/cwsandbox/test_sandbox.py
@@ -3213,6 +3213,25 @@ class TestSandboxAnnotations:
 
         assert sandbox._scratch_volume_names == ("default-scratch",)
 
+    def test_from_sandbox_info_initializes_file_fallback_state(self) -> None:
+        """Discovered sandboxes initialize file-operation fallback state."""
+        mock_info = MagicMock()
+        mock_info.sandbox_id = "test-id"
+        mock_info.sandbox_status = SandboxStatus.RUNNING.to_proto()
+        mock_info.started_at_time = None
+        mock_info.runner_id = None
+        mock_info.profile_id = None
+        mock_info.runner_group_id = None
+
+        sandbox = Sandbox._from_sandbox_info(
+            mock_info,
+            base_url="https://test.example.com",
+            timeout_seconds=30.0,
+        )
+
+        assert sandbox._observed_file_op_cap_bytes is None
+        assert sandbox._streaming_fallback_warned is False
+
     def test_from_sandbox_info_default_poll_fields(self) -> None:
         """_from_sandbox_info applies poll defaults when callers omit them."""
         mock_info = MagicMock()


### PR DESCRIPTION
## Summary
- add a `cwsandbox files` command group
- add `files read` for reading sandbox files to stdout or a local output file
- add `files write` for uploading a local file into a sandbox
- add focused unit coverage for registration, options, and error handling

## Tests
- `uv run pytest tests/unit/cwsandbox/test_cli_files.py tests/unit/cwsandbox/test_cli_main.py`
- `uv run pytest tests/unit/cwsandbox/test_cli_*.py tests/unit/cwsandbox/test_sandbox.py -k "cli or from_sandbox_info_initializes_file_fallback_state or from_sandbox_info_initializes_annotations"`
- `uv run ruff check src/cwsandbox/cli src/cwsandbox/_sandbox.py tests/unit/cwsandbox/test_cli_files.py tests/unit/cwsandbox/test_sandbox.py`
- `uv run ruff format --check src/cwsandbox/cli src/cwsandbox/_sandbox.py tests/unit/cwsandbox/test_cli_files.py tests/unit/cwsandbox/test_sandbox.py`
- live smoke test against a real sandbox