### PR TITLE
feat(cli): add snapshots command group

### DIFF
--- a/src/cwsandbox/cli/__init__.py
+++ b/src/cwsandbox/cli/__init__.py
@@ -28,6 +28,7 @@ from cwsandbox.cli.get import get_sandbox
 from cwsandbox.cli.list import list_sandboxes
 from cwsandbox.cli.logs import logs
 from cwsandbox.cli.shell import shell
+from cwsandbox.cli.snapshots import snapshots
 from cwsandbox.exceptions import CWSandboxError
 
 
@@ -56,3 +57,4 @@ cli.add_command(get_sandbox, "get")
 cli.add_command(exec_command, "exec")
 cli.add_command(logs, "logs")
 cli.add_command(shell, "sh")
+cli.add_command(snapshots, "snapshots")

--- a/src/cwsandbox/cli/snapshots.py
+++ b/src/cwsandbox/cli/snapshots.py
@@ -1,0 +1,255 @@
+# SPDX-FileCopyrightText: 2025 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: cwsandbox-client
+
+"""cwsandbox snapshots - manage file-system snapshots."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from enum import Enum
+from typing import Any
+
+import click
+
+from cwsandbox import FileSystemSnapshot, FileSystemSnapshotStatus, Sandbox
+
+_STATUS_CHOICES = [
+    s.value for s in FileSystemSnapshotStatus if s != FileSystemSnapshotStatus.UNSPECIFIED
+]
+
+
+@click.group()
+def snapshots() -> None:
+    """Create, inspect, list, and delete file-system snapshots."""
+
+
+def _enum_value(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, Enum):
+        return str(value.value)
+    return str(value)
+
+
+def _isoformat(value: datetime | None) -> str | None:
+    return value.isoformat() if value is not None else None
+
+
+def _table_time(value: datetime | None) -> str:
+    return value.strftime("%Y-%m-%d %H:%M:%S UTC") if value is not None else "-"
+
+
+def _snapshot_to_dict(snapshot: FileSystemSnapshot) -> dict[str, Any]:
+    return {
+        "file_system_snapshot_id": snapshot.file_system_snapshot_id,
+        "status": _enum_value(snapshot.status),
+        "status_reason": snapshot.status_reason,
+        "size_bytes": snapshot.size_bytes,
+        "source_sandbox_id": snapshot.source_sandbox_id,
+        "trigger": _enum_value(snapshot.trigger),
+        "request_id": snapshot.request_id,
+        "object_bucket": snapshot.object_bucket,
+        "source_volume_name": snapshot.source_volume_name,
+        "created_at": _isoformat(snapshot.created_at),
+        "updated_at": _isoformat(snapshot.updated_at),
+        "completed_at": _isoformat(snapshot.completed_at),
+    }
+
+
+def _echo_snapshots_table(snapshot_rows: list[FileSystemSnapshot]) -> None:
+    click.echo(
+        f"{'SNAPSHOT ID':<40} {'STATUS':<10} {'SOURCE SANDBOX':<40} "
+        f"{'TRIGGER':<10} {'SIZE':>12} {'CREATED AT'}"
+    )
+    click.echo(f"{'-' * 40} {'-' * 10} {'-' * 40} {'-' * 10} {'-' * 12} {'-' * 24}")
+
+    for snapshot in snapshot_rows:
+        snapshot_id = snapshot.file_system_snapshot_id or "-"
+        status = _enum_value(snapshot.status) or "-"
+        source = snapshot.source_sandbox_id or "-"
+        trigger = _enum_value(snapshot.trigger) or "-"
+        created = _table_time(snapshot.created_at)
+        click.echo(
+            f"{snapshot_id:<40} {status:<10} {source:<40} "
+            f"{trigger:<10} {snapshot.size_bytes:>12} {created}"
+        )
+
+
+@snapshots.command("create")
+@click.argument("sandbox_id")
+@click.option(
+    "--wait/--no-wait",
+    "wait_for_ready",
+    default=True,
+    help="Wait for the snapshot to reach READY before returning.",
+)
+@click.option(
+    "--request-id",
+    default=None,
+    help="Client-supplied request ID to deduplicate snapshot creation retries.",
+)
+@click.option(
+    "--timeout",
+    "-t",
+    "timeout_seconds",
+    type=click.FloatRange(min=0, min_open=True),
+    default=None,
+    help="Timeout in seconds for attaching to the sandbox.",
+)
+@click.option(
+    "--output",
+    "-o",
+    "output_format",
+    default="table",
+    type=click.Choice(["table", "json"], case_sensitive=False),
+    help="Output format.",
+)
+def create_snapshot(
+    sandbox_id: str,
+    wait_for_ready: bool,
+    request_id: str | None,
+    timeout_seconds: float | None,
+    output_format: str,
+) -> None:
+    """Create a file-system snapshot from a running sandbox.
+
+    SANDBOX_ID is the ID of the sandbox to snapshot.
+    """
+    sandbox = Sandbox.from_id(sandbox_id, timeout_seconds=timeout_seconds).result()
+    snapshot_id = sandbox.snapshot(
+        wait_for_ready=wait_for_ready,
+        request_id=request_id,
+    ).result()
+
+    if output_format == "json":
+        click.echo(json.dumps({"file_system_snapshot_id": snapshot_id}, indent=2))
+        return
+
+    click.echo(snapshot_id)
+
+
+@snapshots.command("get")
+@click.argument("file_system_snapshot_id")
+@click.option(
+    "--timeout",
+    "-t",
+    "timeout_seconds",
+    type=click.FloatRange(min=0, min_open=True),
+    default=None,
+    help="Timeout in seconds.",
+)
+@click.option(
+    "--output",
+    "-o",
+    "output_format",
+    default="table",
+    type=click.Choice(["table", "json"], case_sensitive=False),
+    help="Output format.",
+)
+def get_snapshot(
+    file_system_snapshot_id: str,
+    timeout_seconds: float | None,
+    output_format: str,
+) -> None:
+    """Get a file-system snapshot by ID."""
+    snapshot = Sandbox.get_snapshot(
+        file_system_snapshot_id,
+        timeout_seconds=timeout_seconds,
+    ).result()
+
+    if output_format == "json":
+        click.echo(json.dumps(_snapshot_to_dict(snapshot), indent=2))
+        return
+
+    _echo_snapshots_table([snapshot])
+
+
+@snapshots.command("list")
+@click.option(
+    "--source-sandbox-id",
+    default=None,
+    help="Only show snapshots captured from this sandbox.",
+)
+@click.option(
+    "--status",
+    "-s",
+    default=None,
+    type=click.Choice(_STATUS_CHOICES, case_sensitive=False),
+    help="Filter by snapshot status.",
+)
+@click.option(
+    "--timeout",
+    "-t",
+    "timeout_seconds",
+    type=click.FloatRange(min=0, min_open=True),
+    default=None,
+    help="Timeout in seconds.",
+)
+@click.option(
+    "--output",
+    "-o",
+    "output_format",
+    default="table",
+    type=click.Choice(["table", "json"], case_sensitive=False),
+    help="Output format.",
+)
+def list_snapshots(
+    source_sandbox_id: str | None,
+    status: str | None,
+    timeout_seconds: float | None,
+    output_format: str,
+) -> None:
+    """List file-system snapshots."""
+    snapshot_rows = Sandbox.list_snapshots(
+        source_sandbox_id=source_sandbox_id,
+        status=status,
+        timeout_seconds=timeout_seconds,
+    ).result()
+
+    if output_format == "json":
+        click.echo(
+            json.dumps([_snapshot_to_dict(snapshot) for snapshot in snapshot_rows], indent=2)
+        )
+        return
+
+    if not snapshot_rows:
+        click.echo("No snapshots found.")
+        return
+
+    _echo_snapshots_table(snapshot_rows)
+
+
+@snapshots.command("delete")
+@click.argument("file_system_snapshot_id")
+@click.option(
+    "--missing-ok",
+    is_flag=True,
+    default=False,
+    help="Succeed if the snapshot is already missing.",
+)
+@click.option(
+    "--timeout",
+    "-t",
+    "timeout_seconds",
+    type=click.FloatRange(min=0, min_open=True),
+    default=None,
+    help="Timeout in seconds.",
+)
+@click.option("--quiet", "-q", is_flag=True, default=False, help="Suppress success output.")
+def delete_snapshot(
+    file_system_snapshot_id: str,
+    missing_ok: bool,
+    timeout_seconds: float | None,
+    quiet: bool,
+) -> None:
+    """Delete a file-system snapshot by ID."""
+    Sandbox.delete_snapshot(
+        file_system_snapshot_id,
+        timeout_seconds=timeout_seconds,
+        missing_ok=missing_ok,
+    ).result()
+
+    if not quiet:
+        click.echo(f"Deleted {file_system_snapshot_id}.")

--- a/tests/unit/cwsandbox/test_cli_snapshots.py
+++ b/tests/unit/cwsandbox/test_cli_snapshots.py
@@ -1,0 +1,239 @@
+# SPDX-FileCopyrightText: 2025 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: cwsandbox-client
+
+"""Tests for cwsandbox snapshots CLI commands."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from cwsandbox import FileSystemSnapshot, FileSystemSnapshotStatus, FileSystemSnapshotTrigger
+from cwsandbox.cli import cli
+from cwsandbox.exceptions import CWSandboxError, SnapshotNotFoundError
+from tests.unit.cwsandbox.conftest import make_operation_ref
+
+
+def _snapshot(snapshot_id: str = "fss-1") -> FileSystemSnapshot:
+    return FileSystemSnapshot(
+        file_system_snapshot_id=snapshot_id,
+        status=FileSystemSnapshotStatus.READY,
+        size_bytes=42,
+        source_sandbox_id="sb-1",
+        trigger=FileSystemSnapshotTrigger.MANUAL,
+        request_id="create-1",
+        object_bucket="bucket-1",
+        source_volume_name="workspace",
+        created_at=datetime(2026, 1, 15, 10, 30, 0, tzinfo=UTC),
+        updated_at=datetime(2026, 1, 15, 10, 31, 0, tzinfo=UTC),
+        completed_at=datetime(2026, 1, 15, 10, 31, 0, tzinfo=UTC),
+    )
+
+
+class TestSnapshotsCommand:
+    """Tests for the cwsandbox snapshots command group."""
+
+    def test_snapshots_registered(self) -> None:
+        """Snapshots command group is registered on the CLI group."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["snapshots", "--help"])
+        assert result.exit_code == 0
+        assert "create" in result.output
+        assert "get" in result.output
+        assert "list" in result.output
+        assert "delete" in result.output
+
+    def test_create_snapshot_prints_id(self) -> None:
+        """cwsandbox snapshots create prints the created snapshot ID."""
+        mock_sandbox = MagicMock()
+        mock_sandbox.snapshot.return_value = make_operation_ref("fss-1")
+
+        with patch("cwsandbox.cli.snapshots.Sandbox") as mock_sandbox_cls:
+            mock_sandbox_cls.from_id.return_value = make_operation_ref(mock_sandbox)
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ["snapshots", "create", "sb-1"])
+
+        assert result.exit_code == 0
+        assert result.output == "fss-1\n"
+        mock_sandbox_cls.from_id.assert_called_once_with("sb-1", timeout_seconds=None)
+        mock_sandbox.snapshot.assert_called_once_with(
+            wait_for_ready=True,
+            request_id=None,
+        )
+
+    def test_create_snapshot_options_and_json(self) -> None:
+        """cwsandbox snapshots create passes options and can emit JSON."""
+        mock_sandbox = MagicMock()
+        mock_sandbox.snapshot.return_value = make_operation_ref("fss-2")
+
+        with patch("cwsandbox.cli.snapshots.Sandbox") as mock_sandbox_cls:
+            mock_sandbox_cls.from_id.return_value = make_operation_ref(mock_sandbox)
+
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                [
+                    "snapshots",
+                    "create",
+                    "sb-1",
+                    "--no-wait",
+                    "--request-id",
+                    "create-1",
+                    "--timeout",
+                    "7",
+                    "--output",
+                    "json",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert json.loads(result.output) == {"file_system_snapshot_id": "fss-2"}
+        mock_sandbox_cls.from_id.assert_called_once_with("sb-1", timeout_seconds=7.0)
+        mock_sandbox.snapshot.assert_called_once_with(
+            wait_for_ready=False,
+            request_id="create-1",
+        )
+
+    def test_get_snapshot_table(self) -> None:
+        """cwsandbox snapshots get displays a snapshot table."""
+        mock_op_ref = make_operation_ref(_snapshot("fss-3"))
+
+        with patch("cwsandbox.cli.snapshots.Sandbox") as mock_sandbox_cls:
+            mock_sandbox_cls.get_snapshot.return_value = mock_op_ref
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ["snapshots", "get", "fss-3"])
+
+        assert result.exit_code == 0
+        assert "SNAPSHOT ID" in result.output
+        assert "fss-3" in result.output
+        assert "ready" in result.output
+        assert "sb-1" in result.output
+        assert "manual" in result.output
+        mock_sandbox_cls.get_snapshot.assert_called_once_with("fss-3", timeout_seconds=None)
+
+    def test_get_snapshot_json(self) -> None:
+        """cwsandbox snapshots get --output json emits snapshot metadata."""
+        with patch("cwsandbox.cli.snapshots.Sandbox") as mock_sandbox_cls:
+            mock_sandbox_cls.get_snapshot.return_value = make_operation_ref(_snapshot("fss-4"))
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ["snapshots", "get", "fss-4", "--output", "json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["file_system_snapshot_id"] == "fss-4"
+        assert data["status"] == "ready"
+        assert data["source_sandbox_id"] == "sb-1"
+        assert data["trigger"] == "manual"
+        assert data["request_id"] == "create-1"
+        assert data["source_volume_name"] == "workspace"
+        assert data["created_at"] == "2026-01-15T10:30:00+00:00"
+
+    def test_list_snapshots_with_filters(self) -> None:
+        """cwsandbox snapshots list passes filters to Sandbox.list_snapshots()."""
+        with patch("cwsandbox.cli.snapshots.Sandbox") as mock_sandbox_cls:
+            mock_sandbox_cls.list_snapshots.return_value = make_operation_ref([])
+
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                [
+                    "snapshots",
+                    "list",
+                    "--source-sandbox-id",
+                    "sb-1",
+                    "--status",
+                    "ready",
+                    "--timeout",
+                    "5",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert "No snapshots found." in result.output
+        mock_sandbox_cls.list_snapshots.assert_called_once_with(
+            source_sandbox_id="sb-1",
+            status="ready",
+            timeout_seconds=5.0,
+        )
+
+    def test_list_snapshots_json(self) -> None:
+        """cwsandbox snapshots list --output json emits a snapshot list."""
+        with patch("cwsandbox.cli.snapshots.Sandbox") as mock_sandbox_cls:
+            mock_sandbox_cls.list_snapshots.return_value = make_operation_ref([_snapshot("fss-5")])
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ["snapshots", "list", "--output", "json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data[0]["file_system_snapshot_id"] == "fss-5"
+        assert data[0]["status"] == "ready"
+
+    def test_delete_snapshot_success(self) -> None:
+        """cwsandbox snapshots delete deletes the selected snapshot."""
+        with patch("cwsandbox.cli.snapshots.Sandbox") as mock_sandbox_cls:
+            mock_sandbox_cls.delete_snapshot.return_value = make_operation_ref(None)
+
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                ["snapshots", "delete", "fss-6", "--missing-ok", "--timeout", "9"],
+            )
+
+        assert result.exit_code == 0
+        assert "Deleted fss-6." in result.output
+        mock_sandbox_cls.delete_snapshot.assert_called_once_with(
+            "fss-6",
+            timeout_seconds=9.0,
+            missing_ok=True,
+        )
+
+    def test_delete_snapshot_quiet(self) -> None:
+        """cwsandbox snapshots delete --quiet suppresses success output."""
+        with patch("cwsandbox.cli.snapshots.Sandbox") as mock_sandbox_cls:
+            mock_sandbox_cls.delete_snapshot.return_value = make_operation_ref(None)
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ["snapshots", "delete", "fss-6", "--quiet"])
+
+        assert result.exit_code == 0
+        assert result.output == ""
+
+    def test_get_snapshot_api_error(self) -> None:
+        """cwsandbox snapshots get shows clean errors for API failures."""
+        mock_op_ref = MagicMock()
+        mock_op_ref.result.side_effect = SnapshotNotFoundError(
+            "not found", file_system_snapshot_id="fss-missing"
+        )
+
+        with patch("cwsandbox.cli.snapshots.Sandbox") as mock_sandbox_cls:
+            mock_sandbox_cls.get_snapshot.return_value = mock_op_ref
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ["snapshots", "get", "fss-missing"])
+
+        assert result.exit_code == 1
+        assert "not found" in result.output
+
+    def test_create_snapshot_api_error(self) -> None:
+        """cwsandbox snapshots create shows clean errors from snapshot()."""
+        mock_sandbox = MagicMock()
+        mock_op_ref = MagicMock()
+        mock_op_ref.result.side_effect = CWSandboxError("snapshot failed")
+        mock_sandbox.snapshot.return_value = mock_op_ref
+
+        with patch("cwsandbox.cli.snapshots.Sandbox") as mock_sandbox_cls:
+            mock_sandbox_cls.from_id.return_value = make_operation_ref(mock_sandbox)
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ["snapshots", "create", "sb-1"])
+
+        assert result.exit_code == 1
+        assert "snapshot failed" in result.output


### PR DESCRIPTION
## Summary
- Add a top-level `cwsandbox snapshots` group with create, get, list, and delete subcommands.
- Support table/json output, source sandbox/status filtering, request IDs, missing-ok deletes, and quiet deletes.
- Add focused unit coverage for the snapshot CLI behavior.

## Test plan
- `UV_CACHE_DIR=/private/tmp/cwsandbox-client-uv-cache uv run mypy src/`
- `UV_CACHE_DIR=/private/tmp/cwsandbox-client-uv-cache uv run pytest tests/unit/cwsandbox/test_cli_*.py tests/unit/cwsandbox/test_file_system_snapshot.py`
- `UV_CACHE_DIR=/private/tmp/cwsandbox-client-uv-cache uv run ruff check src/cwsandbox/cli/snapshots.py tests/unit/cwsandbox/test_cli_snapshots.py src/cwsandbox/cli/__init__.py`
- `UV_CACHE_DIR=/private/tmp/cwsandbox-client-uv-cache uv run ruff format --check src/cwsandbox/cli/snapshots.py tests/unit/cwsandbox/test_cli_snapshots.py src/cwsandbox/cli/__init__.py`
- `git diff --check`
- Live smoke test against a real sandbox covering snapshots create/get/list/delete.
