### PR TITLE
feat: add create-time HTTPS/OPEN endpoint support for public services

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,17 +65,16 @@ Properties:
 - `status`: Cached status from last API call (use `get_status()` for fresh)
 - `status_updated_at`: When status was last fetched
 - `sandbox_id`, `runner_id`, `runner_group_id`, `returncode`, `started_at`
-- `service_urls`: Tuple of `(port, name, url)` from typed services once ready (empty until reported)
+- `service_urls`: Tuple of `(port, name, url)` from typed services once assigned (CREATING or RUNNING; not serving)
 - `exposed_ports`: `(port, name)` pairs derived from status services when present
 - `resource_requests`, `resource_limits` - Confirmed resources from start response (None for discovered sandboxes)
 - `file_system_snapshot_id` - Snapshot ID produced by `stop(snapshot_on_stop=True)` once the stop resolves (None otherwise)
-- `service_urls` - Per-service ``(port, name, url)`` tuples once the backend reports them
 
 Advanced configuration kwargs (for `run()`, `run_from_template()`, `Session.sandbox()`, and `@session.function()`):
 - `placement_mode` - `PlacementMode` (`serverless` / `cks`) or string; first-attempt mode when using spillover
 - `placement_spillover` - `PlacementSpillover` (`strict` default | `cks_then_serverless` | `serverless_then_cks`). On CreateSandbox failure when the primary mode cannot place the request (`CWSANDBOX_RUNNER_CAPACITY_EXHAUSTED`, `CWSANDBOX_PLACEMENT_REJECTED`, `CWSANDBOX_PLACEMENT_CONSTRAINT_UNSATISFIED`, `CWSANDBOX_NO_SUITABLE_RUNNER`, `CWSANDBOX_RUNNER_OVERLOADED`, `CWSANDBOX_RUNNER_UNAVAILABLE`), retries once with the alternate mode and a new `request_id`. CKS→serverless clears `runner_ids`. `serverless_then_cks` rejects `runner_ids` at construction. Does not spill on serverless product gates, auth, or `INVALID_ARGUMENT`. Template creates (`template_id` / `run_from_template`) require `strict`.
 - `runner_ids` - CKS runner pin (rejected with serverless and with `serverless_then_cks`)
-- `services` - Typed ports via `Service` / `ServiceVisibility` / `ServiceProtocol`
+- `services` - Typed ports via `Service` / `ServiceVisibility` / `ServiceProtocol` / `Endpoint`
 - `network` - `NetworkOptions` deny flags only (`deny_egress` / `deny_ingress`), or dict
 - `volumes` - Named scratch volumes via `ScratchVolumeOptions`
 - `file_system_snapshot` - Convenience single-mount FSS via `FileSystemSnapshotOptions` or dict (`mount_path`, optional `size`, optional `file_system_snapshot_id`, optional `name` default `"workspace"`)
@@ -188,15 +187,35 @@ data = await ref
 
 **`PlacementSpillover`** (`_types.py`): `STRICT` (default) | `CKS_THEN_SERVERLESS` | `SERVERLESS_THEN_CKS`. Client-side one-shot CreateSandbox retry onto the alternate mode on spillable capacity/placement failures. Templates require `STRICT`.
 
-**`Service` / `ServiceVisibility` / `ServiceProtocol`** (`_types.py`): Typed service ports replace beta string ingress/egress modes. Pass as `services=` on `run()` / defaults.
+**`Service` / `ServiceVisibility` / `ServiceProtocol` / `Endpoint`** (`_types.py`): Typed service ports replace beta string ingress/egress modes. Pass as `services=` on `run()` / defaults. HTTPS is create-time only: `visibility=PUBLIC` plus `endpoint=Endpoint(kind=HTTPS, auth=OPEN)`.
 
 ```python
-from cwsandbox import PlacementMode, Service, ServiceVisibility, Sandbox
-
-sandbox = Sandbox.run(
-    services=[Service(port=8080, visibility=ServiceVisibility.PUBLIC)],
+from cwsandbox import (
+    Endpoint,
+    EndpointAuth,
+    EndpointKind,
+    PlacementMode,
+    Sandbox,
+    Service,
+    ServiceVisibility,
 )
 
+sb = Sandbox.run(
+    "python3", "-m", "http.server", "8080",
+    services=[
+        Service(
+            port=8080,
+            name="web",
+            visibility=ServiceVisibility.PUBLIC,
+            endpoint=Endpoint(kind=EndpointKind.HTTPS, auth=EndpointAuth.OPEN),
+        ),
+    ],
+)
+sb.wait()  # RUNNING only
+if not sb.service_urls:
+    sb.get_status()
+url = {port: u for port, _, u in sb.service_urls}[8080]
+# assigned https://8080-<id>.… — the process could still be starting
 # CKS pin
 sandbox = Sandbox.run(
     placement_mode=PlacementMode.CKS,
@@ -441,7 +460,7 @@ The API reference generator in `coreweave/docs` needs `MANIFEST_GROUPS` updated 
 
 ### Unsupported on 1.0 (not a hybrid fallback)
 
-These were never public 0.26 SDK surfaces and remain unsupported until v1 backends implement them: Settings **WIF admin**, **SecretStore admin** CRUD, **NetworkService** / `network_ids`, **TOKEN** / TLS_PASSTHROUGH product endpoints, mixed PRIVATE+PUBLIC on one sandbox. Create-time `Secret` inject and FSS bucket get/set still work.
+These were never public 0.26 SDK surfaces and remain unsupported until v1 backends implement them: Settings **WIF admin**, **SecretStore admin** CRUD, **NetworkService** / `network_ids`, **TOKEN** / TLS_PASSTHROUGH product endpoints, mixed PRIVATE+PUBLIC on one sandbox. Create-time `Secret` inject, FSS bucket get/set, and HTTPS/OPEN endpoints still work.
 
 ### Backend Communication
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,35 +187,15 @@ data = await ref
 
 **`PlacementSpillover`** (`_types.py`): `STRICT` (default) | `CKS_THEN_SERVERLESS` | `SERVERLESS_THEN_CKS`. Client-side one-shot CreateSandbox retry onto the alternate mode on spillable capacity/placement failures. Templates require `STRICT`.
 
-**`Service` / `ServiceVisibility` / `ServiceProtocol` / `Endpoint`** (`_types.py`): Typed service ports replace beta string ingress/egress modes. Pass as `services=` on `run()` / defaults. HTTPS is create-time only: `visibility=PUBLIC` plus `endpoint=Endpoint(kind=HTTPS, auth=OPEN)`.
+**`Service` / `ServiceVisibility` / `ServiceProtocol` / `Endpoint`** (`_types.py`): Typed service ports replace beta string ingress/egress modes. Pass as `services=` on `run()` / defaults. HTTPS is create-time only: `endpoint=Endpoint(kind=HTTPS, auth=OPEN)` on PUBLIC. Listen-only PUBLIC or PRIVATE plus a product endpoint is `CWSANDBOX_NOT_IMPLEMENTED`.
 
 ```python
-from cwsandbox import (
-    Endpoint,
-    EndpointAuth,
-    EndpointKind,
-    PlacementMode,
-    Sandbox,
-    Service,
-    ServiceVisibility,
+from cwsandbox import PlacementMode, Service, ServiceVisibility, Sandbox
+
+sandbox = Sandbox.run(
+    services=[Service(port=8080, visibility=ServiceVisibility.PUBLIC)],
 )
 
-sb = Sandbox.run(
-    "python3", "-m", "http.server", "8080",
-    services=[
-        Service(
-            port=8080,
-            name="web",
-            visibility=ServiceVisibility.PUBLIC,
-            endpoint=Endpoint(kind=EndpointKind.HTTPS, auth=EndpointAuth.OPEN),
-        ),
-    ],
-)
-sb.wait()  # RUNNING only
-if not sb.service_urls:
-    sb.get_status()
-url = {port: u for port, _, u in sb.service_urls}[8080]
-# assigned https://8080-<id>.… — the process could still be starting
 # CKS pin
 sandbox = Sandbox.run(
     placement_mode=PlacementMode.CKS,
@@ -460,7 +440,7 @@ The API reference generator in `coreweave/docs` needs `MANIFEST_GROUPS` updated 
 
 ### Unsupported on 1.0 (not a hybrid fallback)
 
-These were never public 0.26 SDK surfaces and remain unsupported until v1 backends implement them: Settings **WIF admin**, **SecretStore admin** CRUD, **NetworkService** / `network_ids`, **TOKEN** / TLS_PASSTHROUGH product endpoints, mixed PRIVATE+PUBLIC on one sandbox. Create-time `Secret` inject, FSS bucket get/set, and HTTPS/OPEN endpoints still work.
+These were never public 0.26 SDK surfaces and remain unsupported until v1 backends implement them: Settings **WIF admin**, **SecretStore admin** CRUD, **NetworkService** / `network_ids`, **TOKEN** / TLS_PASSTHROUGH product endpoints, mixed PRIVATE+PUBLIC on one sandbox. Create-time `Secret` inject and FSS bucket get/set still work.
 
 ### Backend Communication
 

--- a/src/cwsandbox/__init__.py
+++ b/src/cwsandbox/__init__.py
@@ -28,6 +28,9 @@ from cwsandbox._loop_manager import _LoopManager
 from cwsandbox._sandbox import Sandbox, SandboxStatus
 from cwsandbox._session import Session
 from cwsandbox._types import (
+    Endpoint,
+    EndpointAuth,
+    EndpointKind,
     FileSystemSnapshot,
     FileSystemSnapshotBucketConfig,
     FileSystemSnapshotBucketMode,
@@ -283,6 +286,9 @@ __all__ = [
     "CWSandboxAuthenticationError",
     "CWSandboxError",
     "DiscoveryError",
+    "Endpoint",
+    "EndpointAuth",
+    "EndpointKind",
     "FileSystemSnapshot",
     "FileSystemSnapshotBucketConfig",
     "FileSystemSnapshotBucketMode",

--- a/src/cwsandbox/_sandbox.py
+++ b/src/cwsandbox/_sandbox.py
@@ -113,6 +113,9 @@ from cwsandbox._proto import (
 )
 from cwsandbox._resources import normalize_resources
 from cwsandbox._types import (
+    Endpoint,
+    EndpointAuth,
+    EndpointKind,
     ExecOutcome,
     FileSystemSnapshot,
     FileSystemSnapshotBucketConfig,
@@ -2912,11 +2915,11 @@ class Sandbox:
 
     @property
     def service_urls(self) -> tuple[tuple[int, str, str], ...]:
-        """Per-service URLs reported by the backend once ready.
+        """Per-service URLs assigned by the backend.
 
-        Each entry is ``(port, name, url)``. Empty until the sandbox reports
-        service status (typically after RUNNING). Uses ``ServiceStatus.url``,
-        falling back to ``endpoint.url`` when the top-level URL is empty.
+        Each entry is ``(port, name, url)``. A URL can appear while CREATING
+        or RUNNING. Empty until a URL is assigned, when none was requested, or
+        after the sandbox stops. Assigned is not the same as the app listening.
 
         Custom-visibility services often have no URL from the API; the SDK
         does not invent one. Those services still appear in
@@ -3839,6 +3842,24 @@ class Sandbox:
                     proto_svc.visibility = cast(
                         sandbox_pb2.Visibility,
                         sandbox_pb2.Visibility.Value(f"VISIBILITY_{visibility.name}"),
+                    )
+                endpoint = svc.endpoint
+                if isinstance(endpoint, dict):
+                    endpoint = Endpoint(**endpoint)
+                if isinstance(endpoint, Endpoint):
+                    kind = endpoint.kind
+                    auth = endpoint.auth
+                    if isinstance(kind, str):
+                        kind = EndpointKind(kind.lower())
+                    if isinstance(auth, str):
+                        auth = EndpointAuth(auth.lower())
+                    proto_svc.endpoint.kind = cast(
+                        sandbox_pb2.EndpointKind,
+                        sandbox_pb2.EndpointKind.Value(f"ENDPOINT_KIND_{kind.name}"),
+                    )
+                    proto_svc.endpoint.auth = cast(
+                        sandbox_pb2.EndpointAuth,
+                        sandbox_pb2.EndpointAuth.Value(f"ENDPOINT_AUTH_{auth.name}"),
                     )
                 services.append(proto_svc)
 

--- a/src/cwsandbox/_types.py
+++ b/src/cwsandbox/_types.py
@@ -169,6 +169,41 @@ class ServiceProtocol(StrEnum):
     SCTP = "sctp"
 
 
+class EndpointKind(StrEnum):
+    """HTTPS is the only supported endpoint kind."""
+
+    HTTPS = "https"
+
+
+class EndpointAuth(StrEnum):
+    """OPEN is the only supported endpoint auth (no token required)."""
+
+    OPEN = "open"
+
+
+@dataclass(frozen=True, kw_only=True)
+class Endpoint:
+    """Public HTTPS URL for a service. Set at create time; CoreWeave terminates TLS.
+
+    ``kind`` and ``auth`` are required. Only HTTPS + OPEN is supported.
+    A URL in ``Sandbox.service_urls`` means the hostname was assigned, not
+    that the app is listening yet.
+
+    Attributes:
+        kind: ``HTTPS``.
+        auth: ``OPEN`` (no platform token required).
+    """
+
+    kind: EndpointKind | str
+    auth: EndpointAuth | str
+
+    def __post_init__(self) -> None:
+        if isinstance(self.kind, str):
+            object.__setattr__(self, "kind", EndpointKind(self.kind.lower()))
+        if isinstance(self.auth, str):
+            object.__setattr__(self, "auth", EndpointAuth(self.auth.lower()))
+
+
 @dataclass(frozen=True, kw_only=True)
 class Service:
     """Typed service port exposed by a sandbox.
@@ -178,17 +213,22 @@ class Service:
     Attributes:
         port: Container port the workload listens on.
         name: Optional service name.
-        protocol: L4 protocol (defaults to TCP when unset).
+        protocol: L4 protocol (defaults to TCP when unset). Must be unset or
+            TCP when ``endpoint`` is set.
         visibility: Who may reach this port (PUBLIC/PRIVATE/CUSTOM).
             CUSTOM means the fleet assigns reachability; ``service_urls``
             stays empty unless the API reports a URL. The service still
-            appears in ``exposed_ports``.
+            appears in ``exposed_ports``. Must be PUBLIC when ``endpoint``
+            is set.
+        endpoint: Optional HTTPS URL (HTTPS/OPEN). Omit for a plain TCP/UDP
+            port.
     """
 
     port: int
     name: str | None = None
     protocol: ServiceProtocol | str | None = None
     visibility: ServiceVisibility | str | None = None
+    endpoint: Endpoint | dict[str, Any] | None = None
 
     def __post_init__(self) -> None:
         if self.port <= 0 or self.port > 65535:
@@ -197,6 +237,17 @@ class Service:
             object.__setattr__(self, "protocol", ServiceProtocol(self.protocol.lower()))
         if isinstance(self.visibility, str):
             object.__setattr__(self, "visibility", ServiceVisibility(self.visibility.lower()))
+        if isinstance(self.endpoint, dict):
+            object.__setattr__(self, "endpoint", Endpoint(**self.endpoint))
+        elif self.endpoint is not None and not isinstance(self.endpoint, Endpoint):
+            raise TypeError(
+                f"Service.endpoint must be Endpoint or dict, got {type(self.endpoint).__name__}"
+            )
+        if self.endpoint is not None:
+            if self.visibility != ServiceVisibility.PUBLIC:
+                raise ValueError("Service.visibility must be PUBLIC when endpoint is set")
+            if self.protocol not in (None, ServiceProtocol.UNSPECIFIED, ServiceProtocol.TCP):
+                raise ValueError("Service.protocol must be unset or TCP when endpoint is set")
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/tests/unit/cwsandbox/test_sandbox.py
+++ b/tests/unit/cwsandbox/test_sandbox.py
@@ -19,6 +19,9 @@ import grpc.aio
 import pytest
 
 from cwsandbox import (
+    Endpoint,
+    EndpointAuth,
+    EndpointKind,
     ImagePullCredentials,
     NetworkOptions,
     PlacementMode,
@@ -388,6 +391,57 @@ class TestSandboxRun:
         assert spec.network.deny_ingress is False
         sandbox._state = _Terminal(sandbox_id="matrix-id", status=SandboxStatus.COMPLETED)
 
+    def test_create_request_maps_https_open_endpoint(self) -> None:
+        from cwsandbox._proto import sandbox_pb2
+
+        sandbox, stub = self._run_with_mock_stub(
+            "sleep",
+            "infinity",
+            services=[
+                Service(
+                    name="web",
+                    port=8080,
+                    visibility=ServiceVisibility.PUBLIC,
+                    endpoint=Endpoint(kind=EndpointKind.HTTPS, auth=EndpointAuth.OPEN),
+                ),
+                Service(
+                    name="metrics",
+                    port=9090,
+                    visibility=ServiceVisibility.PUBLIC,
+                ),
+            ],
+        )
+
+        request = stub.CreateSandbox.call_args.args[0]
+        spec = request.sandbox.spec
+        assert spec.services[0].HasField("endpoint")
+        assert spec.services[0].endpoint.kind == sandbox_pb2.ENDPOINT_KIND_HTTPS
+        assert spec.services[0].endpoint.auth == sandbox_pb2.ENDPOINT_AUTH_OPEN
+        assert not spec.services[1].HasField("endpoint")
+        sandbox._state = _Terminal(sandbox_id="matrix-id", status=SandboxStatus.COMPLETED)
+
+    def test_create_request_maps_https_open_endpoint_from_nested_dict(self) -> None:
+        from cwsandbox._proto import sandbox_pb2
+
+        sandbox, stub = self._run_with_mock_stub(
+            "sleep",
+            "infinity",
+            services=[
+                {
+                    "port": 8080,
+                    "visibility": "public",
+                    "endpoint": {"kind": "https", "auth": "open"},
+                }
+            ],
+        )
+
+        request = stub.CreateSandbox.call_args.args[0]
+        ep = request.sandbox.spec.services[0].endpoint
+        assert request.sandbox.spec.services[0].HasField("endpoint")
+        assert ep.kind == sandbox_pb2.ENDPOINT_KIND_HTTPS
+        assert ep.auth == sandbox_pb2.ENDPOINT_AUTH_OPEN
+        sandbox._state = _Terminal(sandbox_id="matrix-id", status=SandboxStatus.COMPLETED)
+
     def test_create_request_maps_scratch_volume(self) -> None:
         sandbox, stub = self._run_with_mock_stub(
             volumes=[
@@ -495,6 +549,27 @@ class TestSandboxRun:
 
         request = stub.CreateSandboxFromTemplate.call_args.args[0]
         assert list(request.overrides.tags) == ["session-tag", "extra"]
+        sandbox._state = _Terminal(sandbox_id="template-id", status=SandboxStatus.COMPLETED)
+
+    def test_run_from_template_maps_https_open_endpoint(self) -> None:
+        from cwsandbox._proto import sandbox_pb2
+
+        sandbox, stub = self._run_with_mock_stub(
+            template_id="template-123",
+            services=[
+                Service(
+                    port=8080,
+                    visibility=ServiceVisibility.PUBLIC,
+                    endpoint=Endpoint(kind=EndpointKind.HTTPS, auth=EndpointAuth.OPEN),
+                )
+            ],
+        )
+
+        request = stub.CreateSandboxFromTemplate.call_args.args[0]
+        assert len(request.overrides.services) == 1
+        assert request.overrides.services[0].HasField("endpoint")
+        assert request.overrides.services[0].endpoint.kind == sandbox_pb2.ENDPOINT_KIND_HTTPS
+        assert request.overrides.services[0].endpoint.auth == sandbox_pb2.ENDPOINT_AUTH_OPEN
         sandbox._state = _Terminal(sandbox_id="template-id", status=SandboxStatus.COMPLETED)
 
     def test_run_from_template_args_without_image_raises(self) -> None:
@@ -5917,6 +5992,68 @@ class TestStoppingStateTransitions:
             (9090, "metrics", "https://sb.example/9090"),
         )
         assert sandbox.exposed_ports == ((8080, "http"), (7070, "custom"))
+
+    def test_apply_sandbox_info_populates_endpoint_url_while_creating(self) -> None:
+        from cwsandbox._proto import sandbox_pb2
+        from cwsandbox._sandbox import _SandboxView
+
+        sandbox = Sandbox(command="sleep", args=["infinity"])
+        sandbox._sandbox_id = "sb-1"
+        sandbox._state = _Starting(sandbox_id="sb-1")
+        sandbox._service_urls = ()
+
+        proto = sandbox_pb2.Sandbox(
+            sandbox_id="sb-1",
+            status=sandbox_pb2.SandboxStatus(
+                state=sandbox_pb2.STATE_CREATING,
+                services=[
+                    sandbox_pb2.ServiceStatus(
+                        port=8080,
+                        name="web",
+                        visibility=sandbox_pb2.VISIBILITY_PUBLIC,
+                        endpoint=sandbox_pb2.EndpointStatus(
+                            kind=sandbox_pb2.ENDPOINT_KIND_HTTPS,
+                            auth=sandbox_pb2.ENDPOINT_AUTH_OPEN,
+                            url="https://8080-sb-1.example",
+                        ),
+                    )
+                ],
+            ),
+        )
+        sandbox._apply_sandbox_info(_SandboxView(proto), source="query")
+
+        assert sandbox.service_urls == ((8080, "web", "https://8080-sb-1.example"),)
+
+    def test_apply_sandbox_info_suppresses_endpoint_url_when_terminal(self) -> None:
+        from cwsandbox._proto import sandbox_pb2
+        from cwsandbox._sandbox import _SandboxView
+
+        sandbox = Sandbox(command="sleep", args=["infinity"])
+        sandbox._sandbox_id = "sb-1"
+        sandbox._state = _Running(sandbox_id="sb-1")
+        sandbox._service_urls = ((8080, "web", "https://8080-sb-1.example"),)
+
+        proto = sandbox_pb2.Sandbox(
+            sandbox_id="sb-1",
+            status=sandbox_pb2.SandboxStatus(
+                state=sandbox_pb2.STATE_COMPLETED,
+                services=[
+                    sandbox_pb2.ServiceStatus(
+                        port=8080,
+                        name="web",
+                        visibility=sandbox_pb2.VISIBILITY_PUBLIC,
+                        endpoint=sandbox_pb2.EndpointStatus(
+                            kind=sandbox_pb2.ENDPOINT_KIND_HTTPS,
+                            auth=sandbox_pb2.ENDPOINT_AUTH_OPEN,
+                            url="",
+                        ),
+                    )
+                ],
+            ),
+        )
+        sandbox._apply_sandbox_info(_SandboxView(proto), source="query")
+
+        assert sandbox.service_urls == ()
 
     def test_stopping_to_running_rejected(self) -> None:
         """_Stopping -> _Running is rejected (stale poll response)."""

--- a/tests/unit/cwsandbox/test_sandbox.py
+++ b/tests/unit/cwsandbox/test_sandbox.py
@@ -387,6 +387,7 @@ class TestSandboxRun:
         assert spec.services[0].port == 8080
         assert spec.services[0].protocol == sandbox_pb2.SERVICE_PROTOCOL_TCP
         assert spec.services[0].visibility == sandbox_pb2.VISIBILITY_PUBLIC
+        assert not spec.services[0].HasField("endpoint")
         assert spec.network.deny_egress is True
         assert spec.network.deny_ingress is False
         sandbox._state = _Terminal(sandbox_id="matrix-id", status=SandboxStatus.COMPLETED)
@@ -404,20 +405,15 @@ class TestSandboxRun:
                     visibility=ServiceVisibility.PUBLIC,
                     endpoint=Endpoint(kind=EndpointKind.HTTPS, auth=EndpointAuth.OPEN),
                 ),
-                Service(
-                    name="metrics",
-                    port=9090,
-                    visibility=ServiceVisibility.PUBLIC,
-                ),
             ],
         )
 
         request = stub.CreateSandbox.call_args.args[0]
         spec = request.sandbox.spec
+        assert len(spec.services) == 1
         assert spec.services[0].HasField("endpoint")
         assert spec.services[0].endpoint.kind == sandbox_pb2.ENDPOINT_KIND_HTTPS
         assert spec.services[0].endpoint.auth == sandbox_pb2.ENDPOINT_AUTH_OPEN
-        assert not spec.services[1].HasField("endpoint")
         sandbox._state = _Terminal(sandbox_id="matrix-id", status=SandboxStatus.COMPLETED)
 
     def test_create_request_maps_https_open_endpoint_from_nested_dict(self) -> None:

--- a/tests/unit/cwsandbox/test_types.py
+++ b/tests/unit/cwsandbox/test_types.py
@@ -12,11 +12,15 @@ from unittest.mock import MagicMock
 import pytest
 
 from cwsandbox._types import (
+    Endpoint,
+    EndpointAuth,
+    EndpointKind,
     NetworkOptions,
     OperationRef,
     Process,
     ProcessResult,
     Service,
+    ServiceProtocol,
     ServiceVisibility,
     StreamReader,
     StreamWriter,
@@ -151,6 +155,80 @@ class TestService:
     def test_invalid_port(self) -> None:
         with pytest.raises(ValueError, match="1-65535"):
             Service(port=0)
+
+    def test_endpoint_required_kind_and_auth(self) -> None:
+        with pytest.raises(TypeError):
+            Endpoint()  # type: ignore[call-arg]
+        ep = Endpoint(kind=EndpointKind.HTTPS, auth=EndpointAuth.OPEN)
+        assert ep.kind == EndpointKind.HTTPS
+        assert ep.auth == EndpointAuth.OPEN
+
+    def test_endpoint_string_coercion(self) -> None:
+        ep = Endpoint(kind="https", auth="open")
+        assert ep.kind == EndpointKind.HTTPS
+        assert ep.auth == EndpointAuth.OPEN
+
+    def test_endpoint_unknown_auth_string(self) -> None:
+        with pytest.raises(ValueError):
+            Endpoint(kind="https", auth="token")
+
+    def test_service_endpoint_nested_dict(self) -> None:
+        svc = Service(
+            port=8080,
+            visibility="public",
+            endpoint={"kind": "https", "auth": "open"},
+        )
+        assert isinstance(svc.endpoint, Endpoint)
+        assert svc.endpoint.kind == EndpointKind.HTTPS
+        assert svc.endpoint.auth == EndpointAuth.OPEN
+
+    def test_service_endpoint_requires_public(self) -> None:
+        with pytest.raises(ValueError, match="PUBLIC"):
+            Service(
+                port=8080,
+                endpoint=Endpoint(kind=EndpointKind.HTTPS, auth=EndpointAuth.OPEN),
+            )
+        with pytest.raises(ValueError, match="PUBLIC"):
+            Service(
+                port=8080,
+                visibility=ServiceVisibility.PRIVATE,
+                endpoint=Endpoint(kind=EndpointKind.HTTPS, auth=EndpointAuth.OPEN),
+            )
+
+    def test_service_endpoint_rejects_non_tcp_protocol(self) -> None:
+        with pytest.raises(ValueError, match="TCP"):
+            Service(
+                port=8080,
+                visibility=ServiceVisibility.PUBLIC,
+                protocol=ServiceProtocol.UDP,
+                endpoint=Endpoint(kind=EndpointKind.HTTPS, auth=EndpointAuth.OPEN),
+            )
+        with pytest.raises(ValueError, match="TCP"):
+            Service(
+                port=8080,
+                visibility=ServiceVisibility.PUBLIC,
+                protocol="sctp",
+                endpoint=Endpoint(kind=EndpointKind.HTTPS, auth=EndpointAuth.OPEN),
+            )
+
+    def test_service_endpoint_allows_unset_or_tcp_protocol(self) -> None:
+        unset = Service(
+            port=8080,
+            visibility=ServiceVisibility.PUBLIC,
+            endpoint=Endpoint(kind=EndpointKind.HTTPS, auth=EndpointAuth.OPEN),
+        )
+        tcp = Service(
+            port=8080,
+            visibility=ServiceVisibility.PUBLIC,
+            protocol=ServiceProtocol.TCP,
+            endpoint=Endpoint(kind=EndpointKind.HTTPS, auth=EndpointAuth.OPEN),
+        )
+        assert unset.protocol is None
+        assert tcp.protocol == ServiceProtocol.TCP
+
+    def test_service_omitted_endpoint_stays_none(self) -> None:
+        svc = Service(port=8080, visibility=ServiceVisibility.PUBLIC)
+        assert svc.endpoint is None
 
 
 class TestProcessResult:


### PR DESCRIPTION
## Summary
- Callers can opt into a create-time HTTPS/OPEN preview URL with `Service(visibility=PUBLIC, endpoint=Endpoint(kind=HTTPS, auth=OPEN))`.
- The SDK sends `EndpointSpec` on Create / CreateFromTemplate. Omitted endpoint stays unset (L4-only PUBLIC on its own sandbox is unchanged). Listen-only PUBLIC or PRIVATE cannot share a sandbox with a product endpoint (`CWSANDBOX_NOT_IMPLEMENTED`); several HTTPS ports on one sandbox are fine.
- `service_urls` means hostname assigned (CREATING or RUNNING), not that the app is serving.

```python
import time

from cwsandbox import (
    Endpoint,
    EndpointAuth,
    EndpointKind,
    Sandbox,
    Service,
    ServiceVisibility,
)

sb = Sandbox.run(
    "python3", "-m", "http.server", "8080",
    services=[
        Service(
            port=8080,
            name="web",
            visibility=ServiceVisibility.PUBLIC,
            endpoint=Endpoint(kind=EndpointKind.HTTPS, auth=EndpointAuth.OPEN),
        ),
    ],
)
sb.wait()  # RUNNING; crash-at-start fails here
deadline = time.monotonic() + 60
while not sb.service_urls and time.monotonic() < deadline:
    sb.get_status()
    time.sleep(0.5)
url = {port: u for port, _, u in sb.service_urls}[8080]
# assigned https://8080-<id>.… — HTTP 200 is the app, not the SDK
```

## Follow-Ups
- TOKEN / TLS_PASSTHROUGH later
- Live HTTPS connectivity e2e (skip on `CWSANDBOX_HTTPS_ENDPOINTS_NOT_SUPPORTED`)
- `coreweave/docs` `MANIFEST_GROUPS` needs the new type names