### PR TITLE
feat: add DNS-name HTTPS egress grants on sandbox create

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ Properties:
 - `sandbox_id`, `runner_id`, `runner_group_id`, `returncode`, `started_at`
 - `service_urls`: Tuple of `(port, name, url)` from typed services once assigned (CREATING or RUNNING; not serving)
 - `exposed_ports`: `(port, name)` pairs derived from status services when present
+- `dns_egress_names`: Hostnames granted at create, echoed from status.effective_egress
 - `resource_requests`, `resource_limits` - Confirmed resources from start response (None for discovered sandboxes)
 - `file_system_snapshot_id` - Snapshot ID produced by `stop(snapshot_on_stop=True)` once the stop resolves (None otherwise)
 
@@ -75,7 +76,7 @@ Advanced configuration kwargs (for `run()`, `run_from_template()`, `Session.sand
 - `placement_spillover` - `PlacementSpillover` (`strict` default | `cks_then_serverless` | `serverless_then_cks`). On CreateSandbox failure when the primary mode cannot place the request (`CWSANDBOX_RUNNER_CAPACITY_EXHAUSTED`, `CWSANDBOX_PLACEMENT_REJECTED`, `CWSANDBOX_PLACEMENT_CONSTRAINT_UNSATISFIED`, `CWSANDBOX_NO_SUITABLE_RUNNER`, `CWSANDBOX_RUNNER_OVERLOADED`, `CWSANDBOX_RUNNER_UNAVAILABLE`), retries once with the alternate mode and a new `request_id`. CKS→serverless clears `runner_ids`. `serverless_then_cks` rejects `runner_ids` at construction. Does not spill on serverless product gates, auth, or `INVALID_ARGUMENT`. Template creates (`template_id` / `run_from_template`) require `strict`.
 - `runner_ids` - CKS runner pin (rejected with serverless and with `serverless_then_cks`)
 - `services` - Typed ports via `Service` / `ServiceVisibility` / `ServiceProtocol` / `Endpoint`
-- `network` - `NetworkOptions` deny flags only (`deny_egress` / `deny_ingress`), or dict
+- `network` - `NetworkOptions` deny flags (`deny_egress` / `deny_ingress`) and optional create-time hostname grants (`egress=[EgressRule(dns_name=...)]`), or dict
 - `volumes` - Named scratch volumes via `ScratchVolumeOptions`
 - `file_system_snapshot` - Convenience single-mount FSS via `FileSystemSnapshotOptions` or dict (`mount_path`, optional `size`, optional `file_system_snapshot_id`, optional `name` default `"workspace"`)
 - `resources` - Resource configuration via `ResourceOptions`, nested dict, or legacy flat dict (CPU, memory, GPU)
@@ -130,7 +131,7 @@ Fields (all optional with sensible defaults):
 - `placement_mode` - `PlacementMode` or string (`serverless` / `cks`)
 - `placement_spillover` - `PlacementSpillover` (default `strict`); see advanced kwargs above
 - `resources` - Resource configuration (`ResourceOptions | dict[str, Any] | None`)
-- `network` - Deny-flag `NetworkOptions`
+- `network` - Deny-flag `NetworkOptions` plus optional `egress` hostname grants
 - `services` - Tuple of typed `Service` ports
 - `volumes` - Tuple of `ScratchVolumeOptions` for named FSS mounts
 - `file_system_snapshot` - Convenience single-mount FSS via `FileSystemSnapshotOptions` (shareable mount_path/size; explicit `run()` value replaces it wholesale)
@@ -203,7 +204,20 @@ sandbox = Sandbox.run(
 )
 ```
 
-**`NetworkOptions`** (`_types.py`): Deny-flag network options only (`deny_egress`, `deny_ingress`). Port exposure is via `services=`, not this type.
+**`NetworkOptions`** / **`EgressRule`** (`_types.py`): Deny flags (`deny_egress`, `deny_ingress`) plus create-time HTTPS hostname grants via `egress=[EgressRule(dns_name=...)]`. Exact names (`pypi.org`) or a single leftmost wildcard (`*.pypi.org`). `"*"` is a policy ceiling, not a sandbox grant. Names are frozen at create. Port exposure is via `services=`, not this type.
+
+```python
+from cwsandbox import EgressRule, NetworkOptions, Sandbox
+
+sandbox = Sandbox.run(
+    network=NetworkOptions(
+        egress=[
+            EgressRule(dns_name="pypi.org"),
+            EgressRule(dns_name="*.pypi.org"),
+        ],
+    ),
+)
+```
 
 **`Secret`** (`_types.py`): Frozen dataclass for injecting secrets from secret stores into sandbox environment variables. The `secrets` parameter accepts `Secret` instances or plain dicts (which are automatically converted via `Secret(**d)`).
 

--- a/src/cwsandbox/AGENTS.md
+++ b/src/cwsandbox/AGENTS.md
@@ -16,7 +16,7 @@ cwsandbox/
 ├── _sandbox.py       # Sandbox class, SandboxStatus enum (largest file)
 ├── _session.py       # Session class for multi-sandbox management
 ├── _function.py      # RemoteFunction for @session.function() decorator
-├── _types.py         # OperationRef, Process, Service, ScratchVolumeOptions, FSS types
+├── _types.py         # OperationRef, Process, Service, EgressRule, ScratchVolumeOptions, FSS types
 ├── _defaults.py      # SandboxDefaults configuration dataclass
 ├── _discovery.py     # list_runners / get_runner (no profiles)
 ├── _auth.py          # Authentication resolution (built-in API key mode, active auth mode override)

--- a/src/cwsandbox/__init__.py
+++ b/src/cwsandbox/__init__.py
@@ -28,6 +28,7 @@ from cwsandbox._loop_manager import _LoopManager
 from cwsandbox._sandbox import Sandbox, SandboxStatus
 from cwsandbox._session import Session
 from cwsandbox._types import (
+    EgressRule,
     Endpoint,
     EndpointAuth,
     EndpointKind,
@@ -292,6 +293,7 @@ __all__ = [
     "CWSandboxValidationError",
     "DiscoveryError",
     "DiscoveryValidationError",
+    "EgressRule",
     "Endpoint",
     "EndpointAuth",
     "EndpointKind",

--- a/src/cwsandbox/_defaults.py
+++ b/src/cwsandbox/_defaults.py
@@ -292,7 +292,8 @@ class SandboxDefaults:
             sandboxes require ``STRICT``.
         resources: Resource configuration. Accepts ``ResourceOptions`` for separate
             requests/limits, or a flat dict for backward-compatible Guaranteed QoS.
-        network: Deny-flag network options via ``NetworkOptions``.
+        network: Deny-flag network options and optional create-time hostname
+            grants via ``NetworkOptions``.
         services: Typed service ports (``Service``) for PUBLIC/PRIVATE/CUSTOM.
         volumes: Named scratch volumes (``ScratchVolumeOptions``) for FSS mounts.
         file_system_snapshot: Convenience single-mount FSS options via

--- a/src/cwsandbox/_sandbox.py
+++ b/src/cwsandbox/_sandbox.py
@@ -2939,8 +2939,8 @@ class Sandbox:
     def dns_egress_names(self) -> tuple[str, ...]:
         """Hostnames granted at create, echoed from ``status.effective_egress``.
 
-        Empty until a create/Get/list response reports name rules, when none
-        were requested, or after the sandbox stops.
+        Empty until a create/Get/list response reports name rules, or when
+        none were requested. Terminal sandboxes keep the last echoed names.
         """
         return self._dns_egress_names
 

--- a/src/cwsandbox/_sandbox.py
+++ b/src/cwsandbox/_sandbox.py
@@ -113,6 +113,7 @@ from cwsandbox._proto import (
 )
 from cwsandbox._resources import normalize_resources
 from cwsandbox._types import (
+    EgressRule,
     Endpoint,
     EndpointAuth,
     EndpointKind,
@@ -1363,6 +1364,7 @@ class Sandbox:
         runner_id: Runner ID where sandbox is running.
         returncode: Exit code if sandbox completed.
         started_at: When sandbox started running.
+        dns_egress_names: Hostnames granted at create (from status.effective_egress).
     """
 
     def __init__(
@@ -1428,8 +1430,9 @@ class Sandbox:
                 use ``sandbox.write_file()`` after the sandbox is running.
             s3_mount: Removed in 1.x; passing a value raises ``TypeError``.
             ports: Removed in 1.x; use ``services=[Service(...)]`` instead.
-            network: Deny-flag ``NetworkOptions`` (or dict). Port exposure uses
-                ``services=``.
+            network: ``NetworkOptions`` (or dict) with deny flags and optional
+                create-time hostname grants (``egress=[EgressRule(dns_name=...)]``).
+                Port exposure uses ``services=``.
             placement_mode: ``PlacementMode`` or string (``serverless`` / ``cks``).
             placement_spillover: ``PlacementSpillover`` or string. Default
                 ``strict`` (no create retry). Non-strict modes retry CreateSandbox
@@ -1531,6 +1534,7 @@ class Sandbox:
         self._image_pull_credentials: ImagePullCredentials | None = None
         self._scratch_volume_names: tuple[str, ...] = ()
         self._service_urls: tuple[tuple[int, str, str], ...] = ()
+        self._dns_egress_names: tuple[str, ...] = ()
         self._file_system_snapshot_ids: tuple[str, ...] = ()
         # Use explicit resources or fall back to defaults, then normalize
         effective_resources = (
@@ -1762,8 +1766,9 @@ class Sandbox:
                 use ``sandbox.write_file()`` after the sandbox is running.
             s3_mount: Removed in 1.x; passing a value raises ``TypeError``.
             ports: Removed in 1.x; use ``services=[Service(...)]`` instead.
-            network: Deny-flag ``NetworkOptions`` (or dict). Port exposure uses
-                ``services=``.
+            network: ``NetworkOptions`` (or dict) with deny flags and optional
+                create-time hostname grants (``egress=[EgressRule(dns_name=...)]``).
+                Port exposure uses ``services=``.
             placement_mode: ``PlacementMode`` or string (``serverless`` / ``cks``).
             placement_spillover: ``PlacementSpillover`` or string. Default
                 ``strict``. See ``Sandbox.__init__``.
@@ -1991,6 +1996,7 @@ class Sandbox:
             else ()
         )
         sandbox._service_urls = ()
+        sandbox._dns_egress_names = ()
         sandbox._file_system_snapshot_id = None
         sandbox._file_system_snapshot_ids = ()
         sandbox._observed_file_op_cap_bytes = None
@@ -2928,6 +2934,15 @@ class Sandbox:
         ``exposed_ports`` when visibility is not ``UNSPECIFIED``.
         """
         return self._service_urls
+
+    @property
+    def dns_egress_names(self) -> tuple[str, ...]:
+        """Hostnames granted at create, echoed from ``status.effective_egress``.
+
+        Empty until a create/Get/list response reports name rules, when none
+        were requested, or after the sandbox stops.
+        """
+        return self._dns_egress_names
 
     @property
     def exposed_ports(self) -> tuple[tuple[int, str], ...] | None:
@@ -3879,6 +3894,13 @@ class Sandbox:
                 network_proto.deny_egress = network.deny_egress
             if network.deny_ingress is not None:
                 network_proto.deny_ingress = network.deny_ingress
+            for rule in network.egress or ():
+                if not isinstance(rule, EgressRule):
+                    raise TypeError(
+                        f"egress entries must be EgressRule or dict, got {type(rule).__name__}"
+                    )
+                proto_rule = network_proto.egress.add()
+                proto_rule.dns_name = rule.dns_name
 
         # Reject removed kwargs loudly.
         for removed in ("s3_mount", "max_timeout_seconds", "profile_ids", "profile_names", "ports"):
@@ -4054,6 +4076,9 @@ class Sandbox:
             if url:
                 service_urls.append((s.port, s.name, url))
         self._service_urls = tuple(service_urls)
+        self._dns_egress_names = tuple(
+            rule.dns_name for rule in status.effective_egress if rule.dns_name
+        )
         if status.services:
             self._exposed_ports = tuple(
                 (s.port, s.name)

--- a/src/cwsandbox/_session.py
+++ b/src/cwsandbox/_session.py
@@ -371,8 +371,8 @@ class Session:
                 use ``sandbox.write_file()`` after the sandbox is running.
             s3_mount: Removed in 1.x; passing a value raises ``TypeError``.
             ports: Removed in 1.x; use ``services=[Service(...)]`` instead.
-            network: Deny-flag ``NetworkOptions`` (or dict). Port exposure uses
-                ``services=``.
+            network: ``NetworkOptions`` (or dict) with deny flags and optional
+                create-time hostname grants. Port exposure uses ``services=``.
             file_system_snapshot: Convenience single-mount FSS options
                 (``FileSystemSnapshotOptions`` or dict). Prefer ``volumes=`` for
                 multi-volume setups.
@@ -714,8 +714,8 @@ class Session:
                 use ``sandbox.write_file()`` after the sandbox is running.
             s3_mount: Removed in 1.x; passing a value raises ``TypeError``.
             ports: Removed in 1.x; use ``services=[Service(...)]`` instead.
-            network: Deny-flag ``NetworkOptions`` (or dict). Port exposure uses
-                ``services=``.
+            network: ``NetworkOptions`` (or dict) with deny flags and optional
+                create-time hostname grants. Port exposure uses ``services=``.
             file_system_snapshot: Convenience single-mount FSS options
                 (``FileSystemSnapshotOptions`` or dict). Prefer ``volumes=`` for
                 multi-volume setups.

--- a/src/cwsandbox/_types.py
+++ b/src/cwsandbox/_types.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import threading
-from collections.abc import Callable, Generator
+from collections.abc import Callable, Generator, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
@@ -251,18 +251,76 @@ class Service:
 
 
 @dataclass(frozen=True, kw_only=True)
-class NetworkOptions:
-    """Network deny flags for sandbox egress/ingress policy.
+class EgressRule:
+    """One create-time egress destination.
 
-    Port exposure uses typed ``services=``; this type only carries deny flags.
+    DNS-name HTTPS grants are the supported destination on this type. Exact
+    names (``pypi.org``) or a single leftmost wildcard (``*.pypi.org``).
+    ``"*"`` is a policy ceiling, not a sandbox grant.
+
+    Attributes:
+        dns_name: Hostname to grant for HTTPS (TCP 443).
+    """
+
+    dns_name: str
+
+    def __post_init__(self) -> None:
+        name = self.dns_name.strip().lower()
+        if not name:
+            raise ValueError("EgressRule.dns_name cannot be empty")
+        if name == "*":
+            raise ValueError(
+                'EgressRule.dns_name cannot be "*"; that is a policy ceiling, not a sandbox grant'
+            )
+        object.__setattr__(self, "dns_name", name)
+
+
+def _coerce_egress_rule(value: EgressRule | Mapping[str, Any]) -> EgressRule:
+    if isinstance(value, EgressRule):
+        return value
+    if isinstance(value, Mapping):
+        return EgressRule(**value)
+    raise TypeError(f"egress entries must be EgressRule or dict, got {type(value).__name__}")
+
+
+@dataclass(frozen=True, kw_only=True)
+class NetworkOptions:
+    """Network deny flags and create-time hostname egress grants.
+
+    Port exposure uses typed ``services=``. ``egress`` lists hostnames the
+    sandbox may reach over HTTPS (TCP 443); the list is frozen at create.
 
     Attributes:
         deny_egress: When True, deny all declared egress (policy default unused).
+            Mutually exclusive with a non-empty ``egress`` list.
         deny_ingress: When True, deny CUSTOM ingress (policy default unused).
+        egress: Hostname grants (``EgressRule`` or dict). Empty/None leaves
+            the runner policy default in effect.
+
+    Examples:
+        Grant PyPI over HTTPS::
+
+            NetworkOptions(
+                egress=[
+                    EgressRule(dns_name="pypi.org"),
+                    EgressRule(dns_name="*.pypi.org"),
+                ],
+            )
     """
 
     deny_egress: bool | None = None
     deny_ingress: bool | None = None
+    egress: Sequence[EgressRule | Mapping[str, Any]] | None = None
+
+    def __post_init__(self) -> None:
+        if self.egress is None:
+            return
+        if isinstance(self.egress, (str, bytes)):
+            raise TypeError("egress must be a sequence of EgressRule or dict, not a string")
+        rules = tuple(_coerce_egress_rule(rule) for rule in self.egress)
+        object.__setattr__(self, "egress", rules)
+        if self.deny_egress is True and rules:
+            raise ValueError("NetworkOptions.deny_egress cannot be combined with egress rules")
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/src/cwsandbox/_types.py
+++ b/src/cwsandbox/_types.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import re
 import threading
 from collections.abc import Callable, Generator, Mapping, Sequence
 from dataclasses import dataclass, field
@@ -250,6 +251,16 @@ class Service:
                 raise ValueError("Service.protocol must be unset or TCP when endpoint is set")
 
 
+# DNS-1123 subdomain, matching k8s IsDNS1123Subdomain used by the gateway.
+_DNS1123_LABEL = r"[a-z0-9](?:[-a-z0-9]*[a-z0-9])?"
+_DNS1123_SUBDOMAIN_RE = re.compile(rf"^{_DNS1123_LABEL}(?:\.{_DNS1123_LABEL})*$")
+_DNS1123_SUBDOMAIN_MAX = 253
+
+
+def _is_dns1123_subdomain(name: str) -> bool:
+    return len(name) <= _DNS1123_SUBDOMAIN_MAX and _DNS1123_SUBDOMAIN_RE.fullmatch(name) is not None
+
+
 @dataclass(frozen=True, kw_only=True)
 class EgressRule:
     """One create-time egress destination.
@@ -271,6 +282,15 @@ class EgressRule:
         if name == "*":
             raise ValueError(
                 'EgressRule.dns_name cannot be "*"; that is a policy ceiling, not a sandbox grant'
+            )
+        if name.startswith("*."):
+            valid = len(name) <= _DNS1123_SUBDOMAIN_MAX and _is_dns1123_subdomain(name[2:])
+        else:
+            valid = _is_dns1123_subdomain(name)
+        if not valid:
+            raise ValueError(
+                "EgressRule.dns_name must be a DNS-1123 subdomain or a single "
+                "leftmost wildcard (*.example.com)"
             )
         object.__setattr__(self, "dns_name", name)
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -146,7 +146,7 @@ Any test path that may create a sandbox - directly via `Sandbox.run()`, indirect
 | `test_sandbox.py` | Sandbox class, status handling, exec, file ops |
 | `test_session.py` | Session class, sandbox management, context managers, reporter lifecycle |
 | `test_wandb.py` | WandbReporter metrics, per-sandbox tracking, lazy run detection |
-| `test_types.py` | OperationRef, ProcessResult, Process, StreamReader |
+| `test_types.py` | OperationRef, ProcessResult, Process, StreamReader, NetworkOptions, EgressRule |
 | `test_utilities.py` | cwsandbox.results(), cwsandbox.wait() utilities |
 
 ### Integration Test Files (`tests/integration/cwsandbox/`)
@@ -154,6 +154,7 @@ Any test path that may create a sandbox - directly via `Sandbox.run()`, indirect
 | File | Coverage |
 |------|----------|
 | `test_sandbox.py` | Sandbox lifecycle, file ops, exec. Uses `require_auth`. |
+| `test_dns_egress.py` | DNS-name HTTPS egress. Uses `require_auth`; skips when no runner admits names. |
 | `test_session.py` | Session management, function execution. Uses `require_auth`. |
 | `test_file_system_snapshot.py` | FSS snapshot/fork/restore/management. Uses `require_auth`; skips gracefully on `SnapshotNotSupportedError` when the org is not FSS-enabled. |
 | `test_wandb.py` | W&B metrics logging. Uses `require_auth`; live checks also need `WANDB_API_KEY`. |

--- a/tests/integration/cwsandbox/test_dns_egress.py
+++ b/tests/integration/cwsandbox/test_dns_egress.py
@@ -16,8 +16,18 @@ from __future__ import annotations
 import pytest
 
 from cwsandbox import EgressRule, NetworkOptions, Sandbox, SandboxDefaults
-from cwsandbox._error_info import CWSANDBOX_NO_SUITABLE_RUNNER
+from cwsandbox._error_info import (
+    CWSANDBOX_NO_SUITABLE_RUNNER,
+    CWSANDBOX_PLACEMENT_CONSTRAINT_UNSATISFIED,
+)
 from cwsandbox.exceptions import SandboxError, SandboxValidationError
+
+_SKIP_PLACEMENT_REASONS = frozenset(
+    {
+        CWSANDBOX_NO_SUITABLE_RUNNER,
+        CWSANDBOX_PLACEMENT_CONSTRAINT_UNSATISFIED,
+    }
+)
 
 GRANTED_EXACT = "pypi.org"
 GRANTED_WILD = "*.pypi.org"
@@ -30,8 +40,8 @@ def _skip_if_dns_egress_unavailable(exc: BaseException) -> None:
         fields = " ".join(v.field for v in exc.field_violations)
         if "dns_name" in f"{fields} {exc}".lower():
             pytest.skip(f"runner policy does not admit DNS-name egress: {exc}")
-    if isinstance(exc, SandboxError) and exc.reason == CWSANDBOX_NO_SUITABLE_RUNNER:
-        pytest.skip(f"no runner advertises DNS-name egress: {exc}")
+    if isinstance(exc, SandboxError) and exc.reason in _SKIP_PLACEMENT_REASONS:
+        pytest.skip(f"no runner can host DNS-name egress: {exc}")
 
 
 def _https_get(sandbox: Sandbox, url: str, *, timeout: float) -> int:

--- a/tests/integration/cwsandbox/test_dns_egress.py
+++ b/tests/integration/cwsandbox/test_dns_egress.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2025 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: cwsandbox-client
+
+"""Integration tests for DNS-name HTTPS egress.
+
+These tests require a running CWSandbox backend whose selected runner
+advertises DNS-name egress and whose policy admits the declared names.
+When the fleet cannot place a name grant, they skip rather than fail.
+
+Set CWSANDBOX_BASE_URL and CWSANDBOX_API_KEY before running.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cwsandbox import EgressRule, NetworkOptions, Sandbox, SandboxDefaults
+from cwsandbox._error_info import CWSANDBOX_NO_SUITABLE_RUNNER
+from cwsandbox.exceptions import SandboxError, SandboxValidationError
+
+GRANTED_EXACT = "pypi.org"
+GRANTED_WILD = "*.pypi.org"
+UNGRANTED = "example.com"
+
+
+def _skip_if_dns_egress_unavailable(exc: BaseException) -> None:
+    """Skip when the fleet cannot admit a dns_name create."""
+    if isinstance(exc, SandboxValidationError):
+        fields = " ".join(v.field for v in exc.field_violations)
+        if "dns_name" in f"{fields} {exc}".lower():
+            pytest.skip(f"runner policy does not admit DNS-name egress: {exc}")
+    if isinstance(exc, SandboxError) and exc.reason == CWSANDBOX_NO_SUITABLE_RUNNER:
+        pytest.skip(f"no runner advertises DNS-name egress: {exc}")
+
+
+def _https_get(sandbox: Sandbox, url: str, *, timeout: float) -> int:
+    probe = (
+        "import sys, urllib.request; "
+        "urllib.request.urlopen(sys.argv[1], timeout=float(sys.argv[2]))"
+    )
+    result = sandbox.exec(
+        ["python", "-c", probe, url, str(timeout)],
+        timeout_seconds=timeout + 15,
+    ).result()
+    return result.returncode
+
+
+@pytest.fixture
+def dns_egress_defaults(sandbox_defaults: SandboxDefaults) -> SandboxDefaults:
+    """Longer lifetime so create can wait out the Envoy init probe."""
+    return sandbox_defaults.with_overrides(max_lifetime_seconds=300)
+
+
+def test_dns_name_https_grant_and_miss(dns_egress_defaults: SandboxDefaults) -> None:
+    """Declared names reach HTTPS; a name outside the grant does not."""
+    network = NetworkOptions(
+        egress=[
+            EgressRule(dns_name=GRANTED_EXACT),
+            EgressRule(dns_name=GRANTED_WILD),
+        ]
+    )
+    try:
+        with Sandbox.run(defaults=dns_egress_defaults, network=network) as sandbox:
+            sandbox.wait()
+            assert GRANTED_EXACT in sandbox.dns_egress_names
+            assert GRANTED_WILD in sandbox.dns_egress_names
+            assert _https_get(sandbox, f"https://{GRANTED_EXACT}", timeout=20.0) == 0
+            assert _https_get(sandbox, f"https://{UNGRANTED}", timeout=8.0) != 0
+    except SandboxError as exc:
+        _skip_if_dns_egress_unavailable(exc)
+        raise

--- a/tests/unit/cwsandbox/test_defaults.py
+++ b/tests/unit/cwsandbox/test_defaults.py
@@ -10,6 +10,7 @@ import math
 import pytest
 
 from cwsandbox import (
+    EgressRule,
     FileSystemSnapshotOptions,
     NetworkOptions,
     ResourceOptions,
@@ -469,6 +470,16 @@ class TestSandboxDefaultsFromDict:
         assert defaults.network is not None
         assert isinstance(defaults.network, NetworkOptions)
         assert defaults.network.deny_egress is True
+
+    def test_from_dict_coerces_network_egress_dicts(self) -> None:
+        """from_dict converts nested egress dicts to EgressRule."""
+        defaults = SandboxDefaults.from_dict(
+            {
+                "network": {"egress": [{"dns_name": "pypi.org"}]},
+            }
+        )
+        assert defaults.network is not None
+        assert defaults.network.egress == (EgressRule(dns_name="pypi.org"),)
 
     def test_from_dict_coerces_secrets_dicts(self) -> None:
         """from_dict converts secret dicts to Secret objects."""

--- a/tests/unit/cwsandbox/test_sandbox.py
+++ b/tests/unit/cwsandbox/test_sandbox.py
@@ -19,6 +19,7 @@ import grpc.aio
 import pytest
 
 from cwsandbox import (
+    EgressRule,
     Endpoint,
     EndpointAuth,
     EndpointKind,
@@ -393,6 +394,62 @@ class TestSandboxRun:
         assert spec.network.deny_egress is True
         assert spec.network.deny_ingress is False
         sandbox._state = _Terminal(sandbox_id="matrix-id", status=SandboxStatus.COMPLETED)
+
+    def test_create_request_maps_dns_name_egress(self) -> None:
+        sandbox, stub = self._run_with_mock_stub(
+            "sleep",
+            "infinity",
+            network=NetworkOptions(
+                egress=[
+                    EgressRule(dns_name="pypi.org"),
+                    {"dns_name": "*.pypi.org"},
+                ]
+            ),
+        )
+
+        request = stub.CreateSandbox.call_args.args[0]
+        names = [rule.dns_name for rule in request.sandbox.spec.network.egress]
+        assert names == ["pypi.org", "*.pypi.org"]
+        assert request.sandbox.spec.network.egress[0].WhichOneof("destination") == "dns_name"
+        sandbox._state = _Terminal(sandbox_id="matrix-id", status=SandboxStatus.COMPLETED)
+
+    def test_create_request_maps_dns_name_egress_from_network_dict(self) -> None:
+        sandbox, stub = self._run_with_mock_stub(
+            network={"egress": [{"dns_name": "pypi.org"}]},
+        )
+
+        request = stub.CreateSandbox.call_args.args[0]
+        assert [rule.dns_name for rule in request.sandbox.spec.network.egress] == ["pypi.org"]
+        sandbox._state = _Terminal(sandbox_id="matrix-id", status=SandboxStatus.COMPLETED)
+
+    def test_create_echoes_dns_egress_names_from_status(self) -> None:
+        from cwsandbox._proto import sandbox_pb2
+
+        response = sandbox_pb2.Sandbox(
+            sandbox_id="dns-id",
+            status=sandbox_pb2.SandboxStatus(
+                state=sandbox_pb2.STATE_PENDING,
+                effective_egress=[
+                    sandbox_pb2.EgressRule(dns_name="pypi.org"),
+                    sandbox_pb2.EgressRule(dns_name="*.pypi.org"),
+                ],
+            ),
+        )
+        mock_stub = MagicMock()
+        mock_stub.CreateSandbox = AsyncMock(return_value=response)
+
+        async def ensure_client(sandbox: Sandbox) -> None:
+            sandbox._channel = MagicMock()
+            sandbox._channel.close = AsyncMock()
+            sandbox._stub = mock_stub
+
+        with patch.object(Sandbox, "_ensure_client", ensure_client):
+            sandbox = Sandbox.run(
+                network=NetworkOptions(egress=[EgressRule(dns_name="pypi.org")]),
+            )
+
+        assert sandbox.dns_egress_names == ("pypi.org", "*.pypi.org")
+        sandbox._state = _Terminal(sandbox_id="dns-id", status=SandboxStatus.COMPLETED)
 
     def test_create_request_maps_https_open_endpoint(self) -> None:
         from cwsandbox._proto import sandbox_pb2

--- a/tests/unit/cwsandbox/test_types.py
+++ b/tests/unit/cwsandbox/test_types.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from cwsandbox._types import (
+    EgressRule,
     Endpoint,
     EndpointAuth,
     EndpointKind,
@@ -117,13 +118,38 @@ class TestOperationRef:
             assert result == 42
 
 
+class TestEgressRule:
+    """Tests for create-time DNS-name egress grants."""
+
+    def test_normalizes_dns_name(self) -> None:
+        rule = EgressRule(dns_name="  PyPI.org ")
+        assert rule.dns_name == "pypi.org"
+
+    def test_wildcard_allowed(self) -> None:
+        assert EgressRule(dns_name="*.pypi.org").dns_name == "*.pypi.org"
+
+    def test_empty_rejected(self) -> None:
+        with pytest.raises(ValueError, match="cannot be empty"):
+            EgressRule(dns_name="   ")
+
+    def test_star_ceiling_rejected(self) -> None:
+        with pytest.raises(ValueError, match="policy ceiling"):
+            EgressRule(dns_name="*")
+
+    def test_frozen(self) -> None:
+        rule = EgressRule(dns_name="pypi.org")
+        with pytest.raises(AttributeError):
+            rule.dns_name = "example.com"  # type: ignore[misc]
+
+
 class TestNetworkOptions:
-    """Tests for v1 NetworkOptions (deny flags; typed services are separate)."""
+    """Tests for v1 NetworkOptions (deny flags and hostname grants)."""
 
     def test_default_values_all_none(self) -> None:
         opts = NetworkOptions()
         assert opts.deny_egress is None
         assert opts.deny_ingress is None
+        assert opts.egress is None
 
     def test_deny_flags(self) -> None:
         opts = NetworkOptions(deny_egress=True, deny_ingress=False)
@@ -143,6 +169,21 @@ class TestNetworkOptions:
         assert opts1 != opts3
         hash(opts1)
         assert "NetworkOptions" in repr(opts1)
+
+    def test_egress_coerces_dicts_and_lists(self) -> None:
+        opts = NetworkOptions(egress=[{"dns_name": "pypi.org"}, EgressRule(dns_name="*.pypi.org")])
+        assert opts.egress == (
+            EgressRule(dns_name="pypi.org"),
+            EgressRule(dns_name="*.pypi.org"),
+        )
+
+    def test_deny_egress_with_names_rejected(self) -> None:
+        with pytest.raises(ValueError, match="cannot be combined"):
+            NetworkOptions(deny_egress=True, egress=[EgressRule(dns_name="pypi.org")])
+
+    def test_egress_rejects_bare_string(self) -> None:
+        with pytest.raises(TypeError, match="sequence"):
+            NetworkOptions(egress="pypi.org")  # type: ignore[arg-type]
 
 
 class TestService:

--- a/tests/unit/cwsandbox/test_types.py
+++ b/tests/unit/cwsandbox/test_types.py
@@ -136,6 +136,24 @@ class TestEgressRule:
         with pytest.raises(ValueError, match="policy ceiling"):
             EgressRule(dns_name="*")
 
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "*.*.pypi.org",
+            "*pypi.org",
+            "foo.*.com",
+            "pypi.org:443",
+            "*.",
+            "*example.com",
+            "**.example.com",
+            "foo.*.example.com",
+            "-bad.example.com",
+        ],
+    )
+    def test_invalid_grammar_rejected(self, name: str) -> None:
+        with pytest.raises(ValueError, match="DNS-1123 subdomain"):
+            EgressRule(dns_name=name)
+
     def test_frozen(self) -> None:
         rule = EgressRule(dns_name="pypi.org")
         with pytest.raises(AttributeError):


### PR DESCRIPTION
## Summary

A sandbox can declare which hostnames it may reach over HTTPS when it is created. Exact names and a one-label wildcard (for example `*.pypi.org`) are accepted. A bare `*` is rejected because that is a fleet policy ceiling, not a per-sandbox grant. Turning off all egress cannot be combined with a hostname list. After create, the SDK reports the granted names from sandbox status.

![DNS-name HTTPS egress at create](https://github.com/user-attachments/assets/3a538204-94a8-493b-9a7a-f7538fa23edd)

## What changed

### Create-time hostname grants

The SDK sends hostname grants on sandbox create and reads them back from status.

- `src/cwsandbox/_types.py` — new `EgressRule` (`dns_name`); `NetworkOptions.egress` accepts rules or dicts, lowercases names, rejects empty/`*`, and rejects `deny_egress=True` with a non-empty list.
- `src/cwsandbox/_sandbox.py` — maps `egress` onto proto `egress[].dns_name`; `dns_egress_names` copies `status.effective_egress`.
- `src/cwsandbox/__init__.py` — exports `EgressRule`.
- `src/cwsandbox/_defaults.py`, `src/cwsandbox/_session.py` — docs; dict `network` still coerces through `NetworkOptions`.

### Tests

- `tests/unit/cwsandbox/test_types.py` — normalize, wildcard, `*` and empty rejection, dict coerce, deny-plus-names conflict.
- `tests/unit/cwsandbox/test_sandbox.py` — create mapping (typed and dict) and status echo.
- `tests/unit/cwsandbox/test_defaults.py` — nested egress dicts in `SandboxDefaults.from_dict`.
- `tests/integration/cwsandbox/test_dns_egress.py` — live grant vs miss against `pypi.org` / `example.com`; skips when the fleet cannot admit names.

### Docs

- `AGENTS.md`, `src/cwsandbox/AGENTS.md`, `tests/AGENTS.md` — public surface and file table.

## Behavior / Key decisions

| Input | Outcome |
| --- | --- |
| `pypi.org` or `*.pypi.org` | sent as `egress[].dns_name` on create |
| `"*"` or empty name | `ValueError` in the client |
| `deny_egress=True` and a non-empty hostname list | `ValueError` in the client |
| status `effective_egress` | `sandbox.dns_egress_names` |

This PR does not add CIDR, selector, or `any` destinations, `dns_name_except`, or a discovery `supports_dns_egress` flag. Vendored protos already had `dns_name`; they were not regenerated.

## Risk surface

This adds a public type (`EgressRule`) and a new field on `NetworkOptions`. Callers that omit `egress` keep deny-flag-only behavior. Hostname lists are create-only; the client does not send updates after create. The API-reference generator in `coreweave/docs` still needs `MANIFEST_GROUPS` updated for the new export (not in this repo).

## Test plan

- [x] `uv run pytest tests/unit` — 1295 passed in this worktree before commit
- [x] ruff format/check and mypy on `src/`
- [ ] `tests/integration/cwsandbox/test_dns_egress.py` — not run here (no `CWSANDBOX_API_KEY`)