### PR TITLE
fix(list): accept include_stopped as alias for show_terminated

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ Advanced configuration kwargs (for `run()`, `run_from_template()`, `Session.sand
 
 Class methods:
 - `Sandbox.session(defaults)`: Create a `Session` for managing multiple sandboxes (sync)
-- `Sandbox.list(tags=None, status=None, runner_ids=None, show_terminated=False, ...)`: Query existing sandboxes, return `OperationRef[list[Sandbox]]`. Use `.result()` to block or `await` in async contexts. By default, terminal sandboxes (completed, failed, terminated) are excluded. Set `show_terminated=True` to include them. `profile_ids` / `profile_names` raise `TypeError`.
+- `Sandbox.list(tags=None, status=None, runner_ids=None, show_terminated=False, include_stopped=None, ...)`: Query existing sandboxes, return `OperationRef[list[Sandbox]]`. Use `.result()` to block or `await` in async contexts. By default, terminal sandboxes (completed, failed, terminated) are excluded. Set `show_terminated=True` to include them. `include_stopped` is accepted as an alias (`wandb==0.28.2` CLI). `profile_ids` / `profile_names` raise `TypeError`.
 - `Sandbox.from_id(sandbox_id)`: Attach to existing sandbox by ID, return `OperationRef[Sandbox]`. Works for both active and stopped sandboxes.
 - `Sandbox.delete(sandbox_id, missing_ok=False)`: Delete sandbox by ID, return `OperationRef[None]`. Raises `SandboxError` on failure. Set `missing_ok=True` to suppress `SandboxNotFoundError` for already-deleted sandboxes.
 - `Sandbox.get_snapshot(file_system_snapshot_id)`: Fetch a `FileSystemSnapshot` record by ID, return `OperationRef[FileSystemSnapshot]`. Snapshots are org-scoped. Raises `SnapshotNotFoundError` if absent.
@@ -104,7 +104,7 @@ Key methods:
 - `session.function()` - decorator for remote function execution
 - `session.adopt(sandbox)` - register an existing Sandbox (from `Sandbox.list()` or `Sandbox.from_id()`) for cleanup when session closes
 - `session.close()` - return `OperationRef[None]` for cleanup
-- `session.list(tags=None, status=None, runner_ids=None, show_terminated=False, adopt=False)` - find sandboxes matching session tags, return `OperationRef[list[Sandbox]]`. Use `.result()` to block or `await` in async contexts. Set `show_terminated=True` to include terminal sandboxes.
+- `session.list(tags=None, status=None, runner_ids=None, show_terminated=False, include_stopped=None, adopt=False)` - find sandboxes matching session tags, return `OperationRef[list[Sandbox]]`. Use `.result()` to block or `await` in async contexts. Set `show_terminated=True` to include terminal sandboxes. `include_stopped` is accepted as an alias.
 - `session.from_id(sandbox_id, adopt=True)` - attach to existing sandbox by ID, return `OperationRef[Sandbox]`
 
 Properties:

--- a/src/cwsandbox/_defaults.py
+++ b/src/cwsandbox/_defaults.py
@@ -208,6 +208,18 @@ def _merge_dicts(base: dict[str, str], additional: dict[str, str] | None) -> dic
     return merged
 
 
+def _resolve_show_terminated(show_terminated: bool, include_stopped: bool | None) -> bool:
+    """Merge the v1 list flag with the pre-1.0 ``include_stopped`` alias.
+
+    ``wandb==0.28.2`` still calls ``Sandbox.list(include_stopped=...)``. Treat
+    either flag being True as include-terminal. Omitted ``include_stopped``
+    leaves ``show_terminated`` unchanged.
+    """
+    if include_stopped is None:
+        return show_terminated
+    return show_terminated or include_stopped
+
+
 def _normalize_tags(tags: Iterable[str] | None) -> tuple[str, ...]:
     """Normalize tag sequences and reject bare strings.
 

--- a/src/cwsandbox/_sandbox.py
+++ b/src/cwsandbox/_sandbox.py
@@ -68,6 +68,7 @@ from cwsandbox._defaults import (
     SandboxDefaults,
     _normalize_tags,
     _resolve_selector,
+    _resolve_show_terminated,
     _validate_poll_config,
 )
 from cwsandbox._error_info import (
@@ -2051,6 +2052,7 @@ class Sandbox:
         profile_names: list[str] | None = None,
         runner_ids: list[str] | None = None,
         show_terminated: bool = False,
+        include_stopped: bool | None = None,
         base_url: str | None = None,
         timeout_seconds: float | None = None,
         poll_retry_budget_seconds: float | None = None,
@@ -2064,6 +2066,8 @@ class Sandbox:
         By default, only active (non-terminal) sandboxes are returned.
         Set ``show_terminated=True`` to widen the search to include terminal
         sandboxes (completed, failed, terminated).
+        ``include_stopped`` is accepted as an alias for ``show_terminated``
+        (``wandb==0.28.2`` CLI still passes that name).
         A terminal status filter (e.g. ``status="completed"``) also widens
         the search automatically.
 
@@ -2075,6 +2079,8 @@ class Sandbox:
             runner_ids: Filter by runner IDs
             show_terminated: If True, include terminal sandboxes (completed,
                 failed, terminated). Defaults to False.
+            include_stopped: Alias for ``show_terminated``. Either flag being
+                True includes terminal sandboxes.
             base_url: Override API URL (default: CWSANDBOX_BASE_URL env or default)
             timeout_seconds: Request timeout (default: 300s)
             poll_retry_budget_seconds: Wall-clock budget for retrying transient
@@ -2114,7 +2120,7 @@ class Sandbox:
                 profile_ids=profile_ids,
                 profile_names=profile_names,
                 runner_ids=runner_ids,
-                show_terminated=show_terminated,
+                show_terminated=_resolve_show_terminated(show_terminated, include_stopped),
                 base_url=base_url,
                 timeout_seconds=timeout_seconds,
                 poll_retry_budget_seconds=poll_retry_budget_seconds,

--- a/src/cwsandbox/_session.py
+++ b/src/cwsandbox/_session.py
@@ -10,7 +10,12 @@ import logging
 from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar
 
-from cwsandbox._defaults import DEFAULT_BASE_URL, SandboxDefaults, _resolve_selector
+from cwsandbox._defaults import (
+    DEFAULT_BASE_URL,
+    SandboxDefaults,
+    _resolve_selector,
+    _resolve_show_terminated,
+)
 from cwsandbox._function import RemoteFunction
 from cwsandbox._loop_manager import _LoopManager
 from cwsandbox._types import (
@@ -474,6 +479,7 @@ class Session:
         profile_names: builtins.list[str] | None = None,
         runner_ids: builtins.list[str] | None = None,
         show_terminated: bool = False,
+        include_stopped: bool | None = None,
         adopt: bool = False,
     ) -> OperationRef[builtins.list[Sandbox]]:
         """List sandboxes, optionally adopting them into this session.
@@ -485,6 +491,7 @@ class Session:
         By default, only active (non-terminal) sandboxes are returned.
         Set ``show_terminated=True`` to widen the search to include terminal
         sandboxes (completed, failed, terminated).
+        ``include_stopped`` is accepted as an alias for ``show_terminated``.
         A terminal status filter (e.g. ``status="completed"``) also widens
         the search automatically.
 
@@ -496,6 +503,8 @@ class Session:
             runner_ids: Filter by runner IDs (defaults to session's runner_ids if set)
             show_terminated: If True, include terminal sandboxes (completed,
                 failed, terminated). Defaults to False.
+            include_stopped: Alias for ``show_terminated``. Either flag being
+                True includes terminal sandboxes.
             adopt: If True, register discovered sandboxes with this session
                    so they are stopped when the session closes
 
@@ -530,7 +539,7 @@ class Session:
                 profile_ids=profile_ids,
                 profile_names=profile_names,
                 runner_ids=runner_ids,
-                show_terminated=show_terminated,
+                show_terminated=_resolve_show_terminated(show_terminated, include_stopped),
                 adopt=adopt,
             )
         )

--- a/tests/unit/cwsandbox/test_defaults.py
+++ b/tests/unit/cwsandbox/test_defaults.py
@@ -709,3 +709,23 @@ class TestValidatePollConfig:
         from cwsandbox._defaults import _validate_poll_config
 
         _validate_poll_config(30.0, 0.001)  # no raise, any positive finite value
+
+
+class TestResolveShowTerminated:
+    def test_omitted_alias_keeps_show_terminated(self) -> None:
+        from cwsandbox._defaults import _resolve_show_terminated
+
+        assert _resolve_show_terminated(False, None) is False
+        assert _resolve_show_terminated(True, None) is True
+
+    def test_alias_true_includes_terminated(self) -> None:
+        from cwsandbox._defaults import _resolve_show_terminated
+
+        assert _resolve_show_terminated(False, True) is True
+        assert _resolve_show_terminated(True, True) is True
+
+    def test_alias_false_does_not_override_show_terminated(self) -> None:
+        from cwsandbox._defaults import _resolve_show_terminated
+
+        assert _resolve_show_terminated(False, False) is False
+        assert _resolve_show_terminated(True, False) is True

--- a/tests/unit/cwsandbox/test_sandbox.py
+++ b/tests/unit/cwsandbox/test_sandbox.py
@@ -4090,6 +4090,50 @@ class TestSandboxList:
             assert call_args.show_terminated is False
 
     @pytest.mark.asyncio
+    async def test_list_include_stopped_alias_sets_show_terminated(self, mock_api_key: str) -> None:
+        """wandb 0.28.2 CLI still passes include_stopped=True."""
+        from cwsandbox._proto import sandbox_pb2
+
+        mock_channel = MagicMock()
+        mock_channel.close = AsyncMock()
+        mock_stub = MagicMock()
+        mock_stub.ListSandboxes = AsyncMock(
+            return_value=sandbox_pb2.ListSandboxesResponse(sandboxes=[])
+        )
+
+        with (
+            patch("cwsandbox._sandbox.parse_grpc_target", return_value=("test:443", True)),
+            patch("cwsandbox._sandbox.create_channel", return_value=mock_channel),
+            patch("cwsandbox._sandbox.sandbox_pb2_grpc.SandboxServiceStub", return_value=mock_stub),
+        ):
+            await Sandbox.list(include_stopped=True)
+
+            call_args = mock_stub.ListSandboxes.call_args[0][0]
+            assert call_args.show_terminated is True
+
+    @pytest.mark.asyncio
+    async def test_list_include_stopped_false_does_not_set_field(self, mock_api_key: str) -> None:
+        """wandb 0.28.2 CLI always passes include_stopped, default False."""
+        from cwsandbox._proto import sandbox_pb2
+
+        mock_channel = MagicMock()
+        mock_channel.close = AsyncMock()
+        mock_stub = MagicMock()
+        mock_stub.ListSandboxes = AsyncMock(
+            return_value=sandbox_pb2.ListSandboxesResponse(sandboxes=[])
+        )
+
+        with (
+            patch("cwsandbox._sandbox.parse_grpc_target", return_value=("test:443", True)),
+            patch("cwsandbox._sandbox.create_channel", return_value=mock_channel),
+            patch("cwsandbox._sandbox.sandbox_pb2_grpc.SandboxServiceStub", return_value=mock_stub),
+        ):
+            await Sandbox.list(include_stopped=False)
+
+            call_args = mock_stub.ListSandboxes.call_args[0][0]
+            assert call_args.show_terminated is False
+
+    @pytest.mark.asyncio
     async def test_list_propagates_poll_kwargs_to_returned_sandboxes(
         self, mock_api_key: str
     ) -> None:

--- a/tests/unit/cwsandbox/test_session.py
+++ b/tests/unit/cwsandbox/test_session.py
@@ -742,6 +742,32 @@ class TestSessionList:
             assert call_args.show_terminated is True
 
     @pytest.mark.asyncio
+    async def test_list_include_stopped_alias_passes_to_sandbox_list(
+        self, mock_api_key: str
+    ) -> None:
+        """Test session.list(include_stopped=True) aliases to show_terminated."""
+        from cwsandbox._proto import sandbox_pb2
+
+        session = Session()
+
+        mock_channel = MagicMock()
+        mock_channel.close = AsyncMock()
+        mock_stub = MagicMock()
+        mock_stub.ListSandboxes = AsyncMock(
+            return_value=sandbox_pb2.ListSandboxesResponse(sandboxes=[])
+        )
+
+        with (
+            patch("cwsandbox._sandbox.parse_grpc_target", return_value=("test:443", True)),
+            patch("cwsandbox._sandbox.create_channel", return_value=mock_channel),
+            patch("cwsandbox._sandbox.sandbox_pb2_grpc.SandboxServiceStub", return_value=mock_stub),
+        ):
+            await session.list(include_stopped=True)
+
+            call_args = mock_stub.ListSandboxes.call_args[0][0]
+            assert call_args.show_terminated is True
+
+    @pytest.mark.asyncio
     async def test_list_propagates_poll_defaults_to_sandboxes(self, mock_api_key: str) -> None:
         """session.list() passes the defaults' poll fields to returned Sandboxes."""
         from google.protobuf import timestamp_pb2


### PR DESCRIPTION
## Summary
- `wandb==0.28.2` CLI still calls `Sandbox.list(include_stopped=...)` after the v1 rename to `show_terminated`, which makes `wandb beta sandbox ls` crash (`SBX-CLI-002`).
- Accept `include_stopped` as an alias on `Sandbox.list` and `Session.list` so the released W&B CLI keeps working until wandb 0.28.3 (already fixed in wandb/wandb#12482).

## Context
v1 `ListSandboxesRequest` uses `show_terminated` (field 5):

sandbox.proto
Ln 970–979
```
message ListSandboxesRequest {
  ...
  bool show_terminated = 5 [(google.api.field_behavior) = OPTIONAL];
```

v1beta2 has the old name: `include_stopped = 6` on `ListSandboxesRequest` in proto/coreweave/sandbox/v1beta2/gateway.proto.

## Test plan
- [x] `uv run pytest tests/unit/cwsandbox/test_sandbox.py tests/unit/cwsandbox/test_session.py tests/unit/cwsandbox/test_defaults.py -k "include_stopped or ResolveShowTerminated or show_terminated"` → 9 passed
- [x] `Sandbox.list(include_stopped=False)` (wandb 0.28.2 default `ls` path) does not TypeError
- [x] `Sandbox.list(include_stopped=True)` sets proto `show_terminated=True` (unit)
- [x] Live CLI: `wandb==0.28.2` + this branch via `PYTHONPATH`, `wandb beta sandbox ls --entity rnd-team-sandboxes-enabled --output json` → rc=0, parseable JSON
- [ ] After this ships on PyPI, nightly SBX-CLI-002 should pass on `wandb==0.28.2` without waiting for a wandb release


Made with [Cursor](https://cursor.com)