### PR TITLE
feat: add multi-container support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,7 +149,7 @@ Fields (all optional with sensible defaults):
 - `volumes` - Tuple of `ScratchVolumeOptions` / `RegisteredVolumeOptions` (`mount_path` optional on scratch)
 - `runtime_class`, `security_context`, `working_dir`, `object_storage_access` - Create-spec fields shared across sandboxes
 - `file_system_snapshot` - Convenience single-mount FSS via `FileSystemSnapshotOptions` (shareable mount_path/size; explicit `run()` value replaces it wholesale; `mount_path` optional)
-- `containers` - Optional `tuple[Container, ...]`. Mutually exclusive with single-container fields on `Sandbox.run()` / `session.sandbox()`. Do not set this on defaults used with `@session.function()`.
+- `containers` - Optional `tuple[Container, ...]`. Mutually exclusive with single-container fields on `Sandbox.run()` / `session.sandbox()`. `@session.function()` ignores this field and always creates a single-container sandbox.
 - `secrets` - Create-time secret inject (tuple of `Secret`)
 - `environment_variables` - Environment variables to inject
 - `annotations` - Kubernetes pod annotations (`dict[str, str]`, default: empty)
@@ -411,7 +411,7 @@ Arguments, closures, referenced globals, and return values must be
 JSON-serializable (str, int, float, dict, list, bool, None). Non-JSON
 values surface as a `SandboxExecutionError` from inside the sandbox.
 
-`@session.function()` stays a single-container workflow. Do not put `containers` on session defaults used with the decorator.
+`@session.function()` stays a single-container workflow. Session `containers` defaults are ignored when the decorator creates a sandbox.
 
 ### Event Loop Management (`_loop_manager.py`)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,11 +52,11 @@ Key methods:
 - `start()`: Send create request, return `OperationRef[None]`. Call `.result()` to block until backend accepts. Freezes one create `request_id` for idempotent retries.
 - `wait()`: Block until RUNNING status, returns self for chaining
 - `wait_until_complete(timeout=None, raise_on_termination=True)`: Wait until terminal state (COMPLETED, FAILED, TERMINATED), return `OperationRef[Sandbox]`. Polls through TERMINATING automatically. Call `.result()` to block or `await` in async contexts. Set `raise_on_termination=False` to handle externally-terminated sandboxes without raising `SandboxTerminatedError`.
-- `exec(command, cwd=None, check=False, timeout_seconds=None, stdin=False)`: Execute command, return `Process`. Call `.result()` to block for `ProcessResult`. Iterate `process.stdout` before `.result()` for real-time streaming. Set `check=True` to raise `SandboxExecutionError` on non-zero returncode. Set `cwd` to an absolute path to run the command in a specific working directory (implemented via shell wrapping, requires /bin/sh in container). Set `stdin=True` to enable stdin streaming via `process.stdin`.
-- `shell(command=None, *, width=None, height=None)`: Start an interactive TTY session, return `TerminalSession`. Always allocates a TTY and enables stdin. Output is raw bytes (merged stdout/stderr) with no buffering — safe for long-running interactive sessions. Defaults to `["/bin/bash"]`.
-- `stream_logs(*, follow=False, tail_lines=None, since_time=None, timestamps=False)`: Stream logs from the sandbox's main process (PID 1), return `StreamReader[str]`. Only captures stdout/stderr from the command passed to `Sandbox.run()` — output from `exec()` commands is **not** included. Set `follow=True` for continuous streaming (like `tail -f`). Uses bounded queues for backpressure in follow mode.
-- `read_file(path)`: Return `OperationRef[bytes]`
-- `write_file(path, content)`: Return `OperationRef[None]`
+- `exec(command, cwd=None, check=False, timeout_seconds=None, stdin=False, container=None)`: Execute command, return `Process`. Call `.result()` to block for `ProcessResult`. Iterate `process.stdout` before `.result()` for real-time streaming. Set `check=True` to raise `SandboxExecutionError` on non-zero returncode. Set `cwd` to an absolute path to run the command in a specific working directory (implemented via shell wrapping, requires /bin/sh in container). Set `stdin=True` to enable stdin streaming via `process.stdin`. Empty/`None` `container` targets the primary.
+- `shell(command=None, *, width=None, height=None, container=None)`: Start an interactive TTY session, return `TerminalSession`. Always allocates a TTY and enables stdin. Output is raw bytes (merged stdout/stderr) with no buffering — safe for long-running interactive sessions. Defaults to `["/bin/bash"]`. Empty/`None` `container` targets the primary.
+- `stream_logs(*, follow=False, tail_lines=None, since_time=None, timestamps=False, container=None)`: Stream logs from the sandbox's main process (PID 1), return `StreamReader[str]`. Only captures stdout/stderr from the command passed to `Sandbox.run()` — output from `exec()` commands is **not** included. Set `follow=True` for continuous streaming (like `tail -f`). Uses bounded queues for backpressure in follow mode. Empty/`None` `container` targets the primary.
+- `read_file(path, *, container=None)`: Return `OperationRef[bytes]`. Empty/`None` `container` targets the primary.
+- `write_file(path, content, *, container=None)`: Return `OperationRef[None]`. Empty/`None` `container` targets the primary.
 - `stop(snapshot_on_stop=False, graceful_shutdown_seconds=10.0, missing_ok=False, wait_for_ready=True, request_id=None)`: Stop sandbox via DeleteSandbox and return `OperationRef[None]`. The sandbox transitions through TERMINATING (grace period) before reaching a terminal state (COMPLETED or FAILED). The returned OperationRef resolves when the backend confirms a terminal state, not just when the delete RPC succeeds. Multiple callers share the same stop task. Raises `SandboxError` on failure. Set `snapshot_on_stop=True` to capture a file-system snapshot of the configured scratch volume before shutdown — the resulting ID is then available via the `file_system_snapshot_id` property. Because `stop()` coalesces concurrent callers onto one shared stop task, a `snapshot_on_stop=True` request that would join (or observe) a stop not capturing a snapshot — sandbox already stopping/stopped, or a plain `stop()` already in flight — raises `SnapshotOnStopConflictError` rather than completing with no archive; plain stops always coalesce. `wait_for_ready`/`request_id` apply only when `snapshot_on_stop=True` (the client uses a larger timeout when snapshotting, since the stop blocks on the archive). Set `missing_ok=True` to suppress `SandboxNotFoundError`.
 - `snapshot(wait_for_ready=True, request_id=None)`: Capture a file-system snapshot (FSS) of the configured scratch volume without stopping, return `OperationRef[str]` (the new snapshot's ID). Call `Sandbox.get_snapshot(id)` for the full record. Requires a scratch / `file_system_snapshot` mount and the org to be enabled for FSS. Auto-starts the sandbox first if needed. With `wait_for_ready=True` (default) blocks until the snapshot is READY/FAILED. To fork a sandbox, `snapshot()` then `Sandbox.run(file_system_snapshot=FileSystemSnapshotOptions(..., file_system_snapshot_id=<id>))` (or equivalent `volumes=`).
 - `get_status()`: Fetch fresh status from API (sync). Returns cached status for terminal sandboxes (COMPLETED, FAILED, TERMINATED) since terminal states are immutable. TERMINATING is non-terminal and always fetches fresh status.
@@ -72,6 +72,8 @@ Properties:
 - `effective_egress` / `effective_ingress`: Full echoed rule sets from status
 - `effective_runtime_class`: Runtime class applied by the backend
 - `attached_volume_ids`: Registered Volume IDs attached to the sandbox
+- `containers`: Echoed create-time `Container` spec. `primary=True` is filled on the inferred primary so a clone of this list is a valid create.
+- `container_statuses`: Per-container observed state. Sandbox `status` / `returncode` stay primary-owned.
 - `resource_requests`, `resource_limits` - Confirmed resources from start response (None for discovered sandboxes)
 - `file_system_snapshot_id` - Snapshot ID produced by `stop(snapshot_on_stop=True)` once the stop resolves (None otherwise)
 
@@ -81,15 +83,16 @@ Advanced configuration kwargs (for `run()`, `run_from_template()`, `Session.sand
 - `runner_ids` - CKS runner pin (rejected with serverless and with `serverless_then_cks`)
 - `services` - Typed ports via `Service` / `ServiceVisibility` / `ServiceProtocol` / `Endpoint`
 - `network` - `NetworkOptions` deny flags (`deny_egress` / `deny_ingress`) plus create-time `egress` / `ingress` grants (`EgressRule` / `IngressRule`), or dict
-- `volumes` - Scratch (`ScratchVolumeOptions`) or registered (`RegisteredVolumeOptions`) volumes
+- `volumes` - Scratch (`ScratchVolumeOptions`) or registered (`RegisteredVolumeOptions`) volumes. `mount_path` is optional on scratch (omit to declare without mounting). A set `mount_path` is a convenience mount on the primary.
 - `runtime_class` - Optional runtime-class pin (e.g. `"gvisor"`), clamped by policy
-- `security_context` - In-guest privilege for the primary container (`SecurityContext` or dict)
-- `working_dir` - Working directory for the primary container command
+- `security_context` - In-guest privilege for the primary container (`SecurityContext` or dict). Mutually exclusive with `containers=`.
+- `working_dir` - Working directory for the primary container command. Mutually exclusive with `containers=` (set it on `Container` instead).
 - `object_storage_access` - Temporary object-storage credentials (`ObjectStorageAccess` or dict)
-- `file_system_snapshot` - Convenience single-mount FSS via `FileSystemSnapshotOptions` or dict (`mount_path`, optional `size`, optional `file_system_snapshot_id`, optional `name` default `"workspace"`)
+- `file_system_snapshot` - Convenience single-mount FSS via `FileSystemSnapshotOptions` or dict (optional `mount_path`, optional `size`, optional `file_system_snapshot_id`, optional `name` default `"workspace"`). Omit `mount_path` to declare without mounting.
+- `containers` - List of `Container`. Mutually exclusive with `container_image`, `command`/`args`, `resources`, `mounted_files`, `secrets`, `image_pull_credentials`, `environment_variables`, `security_context`, and `working_dir`. Not used by `@session.function()`. One container: names/`primary` may be omitted. More than one: every row needs a name and resources, and exactly one `primary=True`. GPU is allowed only on the primary.
 - `resources` - Resource configuration via `ResourceOptions`, nested dict, or legacy flat dict (CPU, memory, GPU)
 - `mounted_files` - Files to mount into the sandbox at startup (read-only at runtime; use `write_file()` for writable files)
-- `image_pull_credentials` - Private registry pull credentials. On `run_from_template()`, requires `container_image` (whole-container replace); omit to keep a credential stored on the template
+- `image_pull_credentials` - Private registry pull credentials. On `run_from_template()`, requires `container_image` (whole-container replace) unless `containers=` replaces the list; omit to keep a credential stored on the template
 - `secrets` - Create-time secret inject from secret stores as env vars, via `Secret` or dict
 - `environment_variables` - Environment variables to inject (merges with defaults)
 - `annotations` - Kubernetes pod annotations (merges with defaults, explicit keys win)
@@ -143,9 +146,10 @@ Fields (all optional with sensible defaults):
 - `resources` - Resource configuration (`ResourceOptions | dict[str, Any] | None`)
 - `network` - Deny-flag `NetworkOptions` plus optional `egress` / `ingress` grants
 - `services` - Tuple of typed `Service` ports
-- `volumes` - Tuple of `ScratchVolumeOptions` / `RegisteredVolumeOptions`
+- `volumes` - Tuple of `ScratchVolumeOptions` / `RegisteredVolumeOptions` (`mount_path` optional on scratch)
 - `runtime_class`, `security_context`, `working_dir`, `object_storage_access` - Create-spec fields shared across sandboxes
-- `file_system_snapshot` - Convenience single-mount FSS via `FileSystemSnapshotOptions` (shareable mount_path/size; explicit `run()` value replaces it wholesale)
+- `file_system_snapshot` - Convenience single-mount FSS via `FileSystemSnapshotOptions` (shareable mount_path/size; explicit `run()` value replaces it wholesale; `mount_path` optional)
+- `containers` - Optional `tuple[Container, ...]`. Mutually exclusive with single-container fields on `Sandbox.run()` / `session.sandbox()`. Do not set this on defaults used with `@session.function()`.
 - `secrets` - Create-time secret inject (tuple of `Secret`)
 - `environment_variables` - Environment variables to inject
 - `annotations` - Kubernetes pod annotations (`dict[str, str]`, default: empty)
@@ -262,6 +266,31 @@ sandbox = Sandbox.run(
 )
 ```
 
+**`Container`** / **`VolumeMount`** / **`ContainerStatus`**: Multi-container create and echo. Pass `containers=[Container(...), ...]` to `Sandbox.run()` / `session.sandbox()`. Volumes stay sandbox-level; sharing is two containers listing the same volume name in `volume_mounts`. The kwargs path (`Sandbox.run("echo", "hello")`) still sends one container named `"main"` with `primary` unset.
+
+```python
+from cwsandbox import Container, ResourceOptions, Sandbox, ScratchVolumeOptions, VolumeMount
+
+with Sandbox.run(
+    containers=[
+        Container(
+            image="python:3.11",
+            name="main",
+            primary=True,
+            resources=ResourceOptions(requests={"cpu": "1"}, limits={"cpu": "1"}),
+            volume_mounts=[VolumeMount(volume="workspace", mount_path="/workspace")],
+        ),
+        Container(
+            image="redis:7",
+            name="cache",
+            resources=ResourceOptions(requests={"cpu": "1"}, limits={"cpu": "1"}),
+        ),
+    ],
+    volumes=[ScratchVolumeOptions(name="workspace")],
+) as sb:
+    sb.exec(["echo", "hello"], container="cache").result()
+```
+
 **`ResourceOptions`** (`_types.py`): Frozen dataclass for typed resource configuration. Supports separate requests and limits for Burstable QoS pods. GPU is a separate top-level field because GPU overcommit is not supported by the backend. The `resources` parameter accepts a `ResourceOptions` instance, a nested dict, or a legacy flat dict (which is automatically coerced).
 
 Fields:
@@ -294,11 +323,11 @@ sandbox = Sandbox.run(
 
 **File System Snapshots (FSS)** (`_types.py`): A configured scratch volume can be snapshotted (on request or on stop) and restored into new sandboxes. FSS is gated per-organization on the backend; orgs that are not enabled get `SnapshotNotSupportedError`.
 
-- **`ScratchVolumeOptions`**: Named scratch mount. Fields: `name`, `mount_path` (absolute), optional `size`, `restore_from_snapshot_id`, `medium` (`disk`/`memory`), `sub_path`, `read_only`. Prefer `volumes=` for multi-volume setups.
+- **`ScratchVolumeOptions`**: Named scratch volume. Fields: `name`, optional `mount_path` (absolute convenience mount on the primary; omit to declare without mounting), optional `size`, `restore_from_snapshot_id`, `medium` (`disk`/`memory`), `sub_path`, `read_only`. Prefer `volumes=` for multi-volume setups. Attach per-container with `Container.volume_mounts`.
 - **`RegisteredVolumeOptions`**: Mount a registered Volume. Fields: `name`, `volume_id`, `mount_path`, optional `sub_path`, `read_only`.
 - **`SecurityContext`**: In-guest privilege (run-as, privileged, capabilities, seccomp). Host-reaching knobs are policy-only.
 - **`ObjectStorageAccess`**: Temporary object-storage credentials (`buckets`, optional `permission`, `object_prefix`).
-- **`FileSystemSnapshotOptions`**: Convenience single-mount wrapper (`mount_path`, optional `size`, optional `file_system_snapshot_id`, optional `name` default `"workspace"`). Maps to a scratch volume via `to_scratch_volume()`.
+- **`FileSystemSnapshotOptions`**: Convenience single-mount wrapper (optional `mount_path`, optional `size`, optional `file_system_snapshot_id`, optional `name` default `"workspace"`). Maps to a scratch volume via `to_scratch_volume()`.
 - **`FileSystemSnapshot`**: Frozen record from `get_snapshot()` / `list_snapshots()` (`snapshot()` returns only the ID). Fields include `file_system_snapshot_id`, `status`, `status_reason`, `size_bytes`, `source_sandbox_id`, `trigger`, `request_id`, `object_bucket`, `source_volume_name`, timestamps.
 - **`FileSystemSnapshotStatus`**: StrEnum — `UNSPECIFIED`, `CREATING`, `READY`, `FAILED`, `DELETING`.
 - **`FileSystemSnapshotTrigger`**: StrEnum — `UNSPECIFIED`, `ON_DELETE` (from `stop(snapshot_on_stop=True)`), `MANUAL` (from `snapshot()`).
@@ -381,6 +410,8 @@ Internals:
 Arguments, closures, referenced globals, and return values must be
 JSON-serializable (str, int, float, dict, list, bool, None). Non-JSON
 values surface as a `SandboxExecutionError` from inside the sandbox.
+
+`@session.function()` stays a single-container workflow. Do not put `containers` on session defaults used with the decorator.
 
 ### Event Loop Management (`_loop_manager.py`)
 

--- a/src/cwsandbox/__init__.py
+++ b/src/cwsandbox/__init__.py
@@ -25,10 +25,11 @@ from cwsandbox._discovery import (
 )
 from cwsandbox._function import RemoteFunction
 from cwsandbox._loop_manager import _LoopManager
-from cwsandbox._sandbox import Sandbox, SandboxStatus
+from cwsandbox._sandbox import ContainerStatus, Sandbox, SandboxStatus
 from cwsandbox._session import Session
 from cwsandbox._types import (
     CidrBlock,
+    Container,
     DataPlaneMode,
     EgressRule,
     Endpoint,
@@ -67,6 +68,7 @@ from cwsandbox._types import (
     TenantScope,
     TerminalResult,
     TerminalSession,
+    VolumeMount,
 )
 from cwsandbox._volume import PvcVolumeSource, Volume, VolumeLocality, VolumeState
 from cwsandbox.exceptions import (
@@ -320,6 +322,8 @@ __all__ = [
     "CWSandboxError",
     "CWSandboxValidationError",
     "CidrBlock",
+    "Container",
+    "ContainerStatus",
     "DataPlaneMode",
     "DiscoveryError",
     "DiscoveryValidationError",
@@ -405,6 +409,7 @@ __all__ = [
     "VolumeError",
     "VolumeInUseError",
     "VolumeLocality",
+    "VolumeMount",
     "VolumeNotFoundError",
     "VolumeNotReadyError",
     "VolumeNotSnapshottableError",

--- a/src/cwsandbox/_defaults.py
+++ b/src/cwsandbox/_defaults.py
@@ -312,8 +312,10 @@ class SandboxDefaults:
         volumes: Scratch or registered volumes (``ScratchVolumeOptions`` or
             ``RegisteredVolumeOptions``).
         runtime_class: Optional runtime-class pin (e.g. ``"gvisor"``).
-        security_context: In-guest privilege for the primary container.
-        working_dir: Working directory for the primary container command.
+        security_context: In-guest privilege for the single-container path.
+            Not applied when ``containers=`` or ``defaults.containers`` is used.
+        working_dir: Working directory for the single-container path.
+            Not applied when a container list is used.
         object_storage_access: Temporary object-storage credentials.
         file_system_snapshot: Convenience single-mount FSS options via
             ``FileSystemSnapshotOptions``. Shareable mount defaults (mount_path,
@@ -321,8 +323,13 @@ class SandboxDefaults:
             ``volumes=`` for multi-volume setups.
         containers: Optional multi-container spec (``Container``). Mutually
             exclusive with single-container fields on ``Sandbox.run()``.
-        secrets: Secrets to inject as environment variables at create time.
-        environment_variables: Environment variables injected into the sandbox.
+            When this list is used, ``secrets``, ``environment_variables``,
+            ``security_context``, and ``working_dir`` on these defaults
+            are not applied; set them on each ``Container``.
+        secrets: Secrets for the single-container path. Not applied when
+            ``containers=`` or ``defaults.containers`` is used.
+        environment_variables: Environment variables for the single-container
+            path. Not applied when a container list is used.
         annotations: Kubernetes pod annotations (key-value string pairs).
             Merged with per-sandbox annotations; explicit values override defaults.
             Use for non-sensitive metadata only.

--- a/src/cwsandbox/_defaults.py
+++ b/src/cwsandbox/_defaults.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from cwsandbox._auth import AuthConfig
 from cwsandbox._types import (
+    Container,
     DataPlaneMode,
     FileSystemSnapshotOptions,
     NetworkOptions,
@@ -23,6 +24,7 @@ from cwsandbox._types import (
     Secret,
     SecurityContext,
     Service,
+    _coerce_container,
     _coerce_object_storage_access,
     _coerce_security_context,
     _coerce_volume_options,
@@ -317,6 +319,8 @@ class SandboxDefaults:
             ``FileSystemSnapshotOptions``. Shareable mount defaults (mount_path,
             size); an explicit ``run()`` value replaces it wholesale. Prefer
             ``volumes=`` for multi-volume setups.
+        containers: Optional multi-container spec (``Container``). Mutually
+            exclusive with single-container fields on ``Sandbox.run()``.
         secrets: Secrets to inject as environment variables at create time.
         environment_variables: Environment variables injected into the sandbox.
         annotations: Kubernetes pod annotations (key-value string pairs).
@@ -364,6 +368,7 @@ class SandboxDefaults:
     working_dir: str | None = None
     object_storage_access: ObjectStorageAccess | dict[str, Any] | None = None
     file_system_snapshot: FileSystemSnapshotOptions | dict[str, Any] | None = None
+    containers: tuple[Container, ...] | None = None
     secrets: tuple[Secret, ...] | None = None
     environment_variables: dict[str, str] = field(default_factory=dict)
     annotations: dict[str, str] = field(default_factory=dict)
@@ -425,10 +430,11 @@ class SandboxDefaults:
         - ``secrets`` list of dicts -> tuple of ``Secret``
         - ``services`` list of dicts -> tuple of ``Service``
         - ``volumes`` list of dicts -> tuple of scratch/registered volume options
+        - ``containers`` list of dicts -> tuple of ``Container``
         - ``security_context`` dict -> ``SecurityContext``
         - ``object_storage_access`` dict -> ``ObjectStorageAccess``
-        - ``args``, ``tags``, ``runner_ids``, ``services``, ``volumes`` lists
-          -> tuples
+        - ``args``, ``tags``, ``runner_ids``, ``services``, ``volumes``,
+          ``containers`` lists -> tuples
         - ``resources``, ``environment_variables`` -> plain ``dict``
         """
         if d is None:
@@ -487,6 +493,9 @@ class SandboxDefaults:
         volumes = kwargs.get("volumes")
         if volumes is not None:
             kwargs["volumes"] = tuple(_coerce_volume_options(v) for v in volumes)
+        containers = kwargs.get("containers")
+        if containers is not None:
+            kwargs["containers"] = tuple(_coerce_container(c) for c in containers)
         kwargs["security_context"] = _coerce_security_context(kwargs.get("security_context"))
         kwargs["object_storage_access"] = _coerce_object_storage_access(
             kwargs.get("object_storage_access")

--- a/src/cwsandbox/_function.py
+++ b/src/cwsandbox/_function.py
@@ -316,9 +316,10 @@ class RemoteFunction(Generic[P, R]):
         # Create sandbox directly and use async start to avoid deadlock.
         # session.sandbox() uses sync APIs which would deadlock when called
         # from the daemon thread running this async method.
+        # Remote functions stay single-container: ignore session containers=.
         sandbox = Sandbox(
             container_image=self._container_image,
-            defaults=self._session._defaults,
+            defaults=self._session._defaults.with_overrides(containers=None),
             _session=self._session,
             **sandbox_kwargs,
         )

--- a/src/cwsandbox/_sandbox.py
+++ b/src/cwsandbox/_sandbox.py
@@ -181,6 +181,7 @@ from cwsandbox._types import (
     _coerce_container,
     _coerce_object_storage_access,
     _coerce_volume_mount,
+    _unique_secrets_by_env_var,
     _validate_containers,
 )
 from cwsandbox.exceptions import (
@@ -334,13 +335,14 @@ class ContainerStatus:
     Attributes:
         name: Container name.
         state: Observed lifecycle state of this container.
-        exit_code: Exit code once the container is COMPLETED or FAILED.
+        exit_code: Exit code once the container is in a terminal state.
+            None while the container is still running.
         restart_count: Times the container has restarted.
     """
 
     name: str
     state: SandboxStatus
-    exit_code: int = 0
+    exit_code: int | None = None
     restart_count: int = 0
 
 
@@ -2003,20 +2005,7 @@ class Sandbox:
             Secret(**s) if isinstance(s, dict) else s for s in (secrets or ())
         ]
         if merged_secrets:
-            seen: dict[str, Secret] = {}
-            for secret in merged_secrets:
-                env_var = secret.env_var
-                assert env_var is not None  # guaranteed by Secret.__post_init__
-                if env_var in seen and secret != seen[env_var]:
-                    raise ValueError(
-                        f"Conflicting secrets for env_var {env_var!r}: "
-                        f"Secret(store={seen[env_var].store!r}, name={seen[env_var].name!r}, "
-                        f"field={seen[env_var].field!r}) vs "
-                        f"Secret(store={secret.store!r}, name={secret.name!r}, "
-                        f"field={secret.field!r})"
-                    )
-                seen[env_var] = secret
-            self._start_kwargs["secrets"] = list(seen.values())
+            self._start_kwargs["secrets"] = list(_unique_secrets_by_env_var(merged_secrets))
 
         self._channel: grpc.aio.Channel | None = None
         self._stub: sandbox_pb2_grpc.SandboxServiceStub | None = None
@@ -4764,15 +4753,18 @@ class Sandbox:
         if echoed and not any(row.primary for row in echoed):
             echoed = (replace(echoed[0], primary=True),) + echoed[1:]
         self._spec_containers = echoed
-        self._container_statuses = tuple(
-            ContainerStatus(
-                name=row.name,
-                state=SandboxStatus.from_proto(row.state),
-                exit_code=row.exit_code,
-                restart_count=row.restart_count,
+        statuses: list[ContainerStatus] = []
+        for row in status.container_statuses:
+            state = SandboxStatus.from_proto(row.state)
+            statuses.append(
+                ContainerStatus(
+                    name=row.name,
+                    state=state,
+                    exit_code=row.exit_code if state in _TERMINAL_STATUSES else None,
+                    restart_count=row.restart_count,
+                )
             )
-            for row in status.container_statuses
-        )
+        self._container_statuses = tuple(statuses)
 
     def _container_from_proto(self, proto: sandbox_pb2.Container) -> Container:
         resources: ResourceOptions | None = None

--- a/src/cwsandbox/_sandbox.py
+++ b/src/cwsandbox/_sandbox.py
@@ -1748,7 +1748,10 @@ class Sandbox:
             containers: Multi-container spec. Mutually exclusive with
                 ``container_image``, ``command``/``args``, ``resources``,
                 ``mounted_files``, ``secrets``, ``image_pull_credentials``,
-                and ``environment_variables``.
+                ``environment_variables``, ``security_context``, and
+                ``working_dir``. This list replaces those single-container
+                fields, including the same names on ``SandboxDefaults``.
+                Put secrets, env, and working_dir on each ``Container``.
         """
         if network is not None:
             if isinstance(network, dict):
@@ -2181,7 +2184,11 @@ class Sandbox:
             containers: Multi-container spec. Mutually exclusive with
                 positional command/args and with ``container_image``,
                 ``resources``, ``mounted_files``, ``secrets``,
-                ``image_pull_credentials``, and ``environment_variables``.
+                ``image_pull_credentials``, ``environment_variables``,
+                ``security_context``, and ``working_dir``. This list
+                replaces those single-container fields, including the
+                same names on ``SandboxDefaults``. Put secrets, env,
+                and working_dir on each ``Container``.
         Returns:
             A Sandbox instance (start request sent, but may still be starting)
 
@@ -4816,7 +4823,7 @@ class Sandbox:
                 name=creds.credentials.path,
                 field=creds.credentials.field,
             )
-        return Container(
+        return Container._from_observed(
             image=proto.image,
             name=proto.name or None,
             command=proto.command or None,

--- a/src/cwsandbox/_sandbox.py
+++ b/src/cwsandbox/_sandbox.py
@@ -29,7 +29,7 @@ from collections.abc import (
     Mapping,
     Sequence,
 )
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar, cast
@@ -142,6 +142,7 @@ from cwsandbox._spec import (
     volumes_to_proto,
 )
 from cwsandbox._types import (
+    Container,
     DataPlaneMode,
     EgressRule,
     Endpoint,
@@ -176,7 +177,11 @@ from cwsandbox._types import (
     StreamWriter,
     TerminalResult,
     TerminalSession,
+    VolumeMount,
+    _coerce_container,
     _coerce_object_storage_access,
+    _coerce_volume_mount,
+    _validate_containers,
 )
 from cwsandbox.exceptions import (
     CWSandboxAuthenticationError,
@@ -317,6 +322,26 @@ class SandboxStatus(StrEnum):
         """Convert SandboxStatus to protobuf State enum."""
         proto_name = f"STATE_{self.name}"
         return sandbox_pb2.State.Value(proto_name)
+
+
+@dataclass(frozen=True, kw_only=True)
+class ContainerStatus:
+    """Observed state of one container on a sandbox.
+
+    Sandbox ``status`` / ``returncode`` stay primary-owned. This row is the
+    kubelet's view of that named container.
+
+    Attributes:
+        name: Container name.
+        state: Observed lifecycle state of this container.
+        exit_code: Exit code once the container is COMPLETED or FAILED.
+        restart_count: Times the container has restarted.
+    """
+
+    name: str
+    state: SandboxStatus
+    exit_code: int = 0
+    restart_count: int = 0
 
 
 def _fss_status_from_proto(value: int) -> FileSystemSnapshotStatus:
@@ -478,16 +503,66 @@ def _coerce_file_system_snapshot(
 
 def _scratch_from_fss_options(
     opts: FileSystemSnapshotOptions,
-) -> tuple[dict[str, Any], dict[str, Any]]:
-    """Return (SandboxVolume kwargs, VolumeMount kwargs) for convenience FSS options."""
+) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    """Return (SandboxVolume kwargs, VolumeMount kwargs or None) for convenience FSS."""
     scratch: dict[str, Any] = {}
     if opts.size is not None:
         scratch["size"] = opts.size
     if opts.file_system_snapshot_id is not None:
         scratch["restore_from_snapshot_id"] = opts.file_system_snapshot_id
-    volume = {"name": DEFAULT_SCRATCH_VOLUME_NAME, "scratch": scratch}
-    mount = {"volume": DEFAULT_SCRATCH_VOLUME_NAME, "mount_path": opts.mount_path}
+    volume = {"name": opts.name or DEFAULT_SCRATCH_VOLUME_NAME, "scratch": scratch}
+    if not opts.mount_path:
+        return volume, None
+    mount = {"volume": volume["name"], "mount_path": opts.mount_path}
     return volume, mount
+
+
+_CONTAINERS_EXCLUSIVE_KWARGS = (
+    "container_image",
+    "command",
+    "args",
+    "resources",
+    "mounted_files",
+    "secrets",
+    "image_pull_credentials",
+    "environment_variables",
+)
+
+
+def _normalize_container_target(container: str | None) -> str | None:
+    if container is None:
+        return None
+    stripped = container.strip()
+    return stripped or None
+
+
+def _set_request_container(message: Any, container: str | None) -> None:
+    target = _normalize_container_target(container)
+    if target:
+        message.container = target
+
+
+def _has_compute_resources(resources: ResourceOptions | None) -> bool:
+    return resources is not None and bool(resources.requests or resources.limits or resources.gpu)
+
+
+def _validate_container_compute(containers: Sequence[Container]) -> None:
+    count = len(containers)
+    for row in containers:
+        is_primary = row.primary or count == 1
+        resources = normalize_resources(row.resources)
+        if count > 1 and not _has_compute_resources(resources):
+            label = row.name or "<unnamed>"
+            raise ValueError(
+                f"container {label!r} requires resources when more than one container is specified"
+            )
+        if resources is not None and resources.gpu and not is_primary:
+            raise ValueError("GPU is only allowed on the primary container")
+
+
+def _containers_conflict_message(conflicts: Sequence[str]) -> str:
+    listed = ", ".join(conflicts)
+    return f"containers= is mutually exclusive with single-container kwargs ({listed})"
 
 
 async def _create_snapshot_via_stub(
@@ -1604,6 +1679,7 @@ class Sandbox:
         annotations: dict[str, str] | None = None,
         secrets: Sequence[Secret | dict[str, Any]] | None = None,
         data_plane_mode: DataPlaneMode | str | None = None,
+        containers: Sequence[Container | Mapping[str, Any]] | None = None,
         _session: Session | None = None,
     ) -> None:
         """Initialize a sandbox (does not start it).
@@ -1667,6 +1743,10 @@ class Sandbox:
                 Merged with defaults (defaults first, then this list).
             data_plane_mode: Transport policy for exec, logs, and file operations.
                 Defaults to ``SandboxDefaults.data_plane_mode``.
+            containers: Multi-container spec. Mutually exclusive with
+                ``container_image``, ``command``/``args``, ``resources``,
+                ``mounted_files``, ``secrets``, ``image_pull_credentials``,
+                and ``environment_variables``.
         """
         if network is not None:
             if isinstance(network, dict):
@@ -1681,18 +1761,55 @@ class Sandbox:
         self._auth = auth if auth is not None else self._defaults.auth
 
         from_template = template_id is not None
+        effective_containers = (
+            containers
+            if containers is not None
+            else (None if from_template else self._defaults.containers)
+        )
+        using_containers = effective_containers is not None
+        if effective_containers is not None:
+            user_containers = _validate_containers(
+                tuple(_coerce_container(row) for row in effective_containers)
+            )
+            _validate_container_compute(user_containers)
+            conflicts = [
+                name
+                for name, value in (
+                    ("container_image", container_image),
+                    ("command", command),
+                    ("args", args),
+                    ("resources", resources),
+                    ("mounted_files", mounted_files),
+                    ("secrets", secrets),
+                    ("image_pull_credentials", image_pull_credentials),
+                    ("environment_variables", environment_variables),
+                    ("security_context", security_context),
+                    ("working_dir", working_dir),
+                )
+                if value is not None
+            ]
+            if conflicts:
+                raise TypeError(_containers_conflict_message(conflicts))
+        else:
+            user_containers = None
+
         # Template creates stay sparse for spec-owned fields (env, annotations,
         # command): SDK defaults would otherwise replace the template. Tags
         # still merge so session.list()/adopt can find the sandbox after a crash.
-        self._command: str | None = command if from_template else command or self._defaults.command
-        self._args: list[str] | None = (
-            args if args is not None else (None if from_template else list(self._defaults.args))
-        )
-
-        # Apply defaults with explicit values taking precedence
-        self._container_image: str | None = (
-            container_image if from_template else container_image or self._defaults.container_image
-        )
+        if using_containers:
+            self._command: str | None = None
+            self._args: list[str] | None = None
+            self._container_image: str | None = None
+        else:
+            self._command = command if from_template else command or self._defaults.command
+            self._args = (
+                args if args is not None else (None if from_template else list(self._defaults.args))
+            )
+            self._container_image = (
+                container_image
+                if from_template
+                else container_image or self._defaults.container_image
+            )
         self._base_url = (
             base_url or os.environ.get("CWSANDBOX_BASE_URL") or self._defaults.base_url
         ).rstrip("/")
@@ -1730,9 +1847,13 @@ class Sandbox:
 
         self._tags: list[str] | None = self._defaults.merge_tags(tags)
         self._environment_variables = (
-            dict(environment_variables or {})
-            if from_template
-            else self._defaults.merge_environment_variables(environment_variables)
+            {}
+            if using_containers
+            else (
+                dict(environment_variables or {})
+                if from_template
+                else self._defaults.merge_environment_variables(environment_variables)
+            )
         )
         self._annotations = (
             dict(annotations or {})
@@ -1769,9 +1890,13 @@ class Sandbox:
         self._service_endpoints: tuple[HttpsEndpointStatus, ...] = ()
         self._dns_egress_names: tuple[str, ...] = ()
         self._file_system_snapshot_ids: tuple[str, ...] = ()
+        self._spec_containers: tuple[Container, ...] = ()
+        self._container_statuses: tuple[ContainerStatus, ...] = ()
         # Use explicit resources or fall back to defaults, then normalize
         effective_resources = (
-            resources if resources is not None or from_template else self._defaults.resources
+            None
+            if using_containers
+            else (resources if resources is not None or from_template else self._defaults.resources)
         )
         normalized = normalize_resources(effective_resources)
         if normalized is not None:
@@ -1853,11 +1978,13 @@ class Sandbox:
         effective_security_context = (
             security_context
             if security_context is not None or from_template
-            else self._defaults.security_context
+            else (None if using_containers else self._defaults.security_context)
         )
         self._security_context = coerce_security_context(effective_security_context)
         effective_working_dir = (
-            working_dir if working_dir is not None or from_template else self._defaults.working_dir
+            working_dir
+            if working_dir is not None or from_template
+            else (None if using_containers else self._defaults.working_dir)
         )
         self._working_dir = effective_working_dir or None
         effective_osa = (
@@ -1866,7 +1993,13 @@ class Sandbox:
             else self._defaults.object_storage_access
         )
         self._object_storage_access = _coerce_object_storage_access(effective_osa)
-        merged_secrets = ([] if from_template else list(self._defaults.secrets or ())) + [
+        if using_containers:
+            assert user_containers is not None
+            self._start_kwargs["containers"] = list(user_containers)
+        inherited_secrets: list[Secret] = (
+            [] if from_template or using_containers else list(self._defaults.secrets or ())
+        )
+        merged_secrets = inherited_secrets + [
             Secret(**s) if isinstance(s, dict) else s for s in (secrets or ())
         ]
         if merged_secrets:
@@ -1994,6 +2127,7 @@ class Sandbox:
         annotations: dict[str, str] | None = None,
         secrets: Sequence[Secret | dict[str, Any]] | None = None,
         data_plane_mode: DataPlaneMode | str | None = None,
+        containers: Sequence[Container | Mapping[str, Any]] | None = None,
     ) -> Sandbox:
         """Create and start a sandbox, return immediately once backend accepts.
 
@@ -2055,6 +2189,10 @@ class Sandbox:
                 Merged with defaults (defaults first, then this list).
             data_plane_mode: Transport policy for exec, logs, and file operations.
                 ``auto`` prefers direct mTLS with gateway fallback.
+            containers: Multi-container spec. Mutually exclusive with
+                positional command/args and with ``container_image``,
+                ``resources``, ``mounted_files``, ``secrets``,
+                ``image_pull_credentials``, and ``environment_variables``.
         Returns:
             A Sandbox instance (start request sent, but may still be starting)
 
@@ -2122,6 +2260,7 @@ class Sandbox:
             annotations=annotations,
             secrets=secrets,
             data_plane_mode=data_plane_mode,
+            containers=containers,
         )
         logger.debug("Creating sandbox with command: %s", command)
         sandbox.start().result()
@@ -2141,19 +2280,21 @@ class Sandbox:
 
         Args:
             template_id: Organization-scoped template UUID.
-            *args: Optional command args override. Requires ``command`` and
-                ``container_image``.
-            command: Optional command override. Requires ``container_image``.
+            *args: Optional command args override. Honored without ``command``.
+                Sparse single-container overlays still require ``container_image``.
+            command: Optional command override. Requires ``container_image``
+                unless ``containers=`` replaces the whole list.
             defaults: Optional SandboxDefaults.
             **kwargs: Same advanced create kwargs as ``run()``. Passing
                 ``container_image`` replaces the whole template container
                 (command, args, env, files, resources, name ``main``); there
-                is no fetch-and-merge. Other container-field overrides
-                (``command``, ``args``, ``environment_variables``,
+                is no fetch-and-merge. ``containers=`` is a full list replace
+                and does not require ``container_image``. Other container-field
+                overlays (``command``, ``args``, ``environment_variables``,
                 ``secrets``, ``resources``, ``mounted_files``, ``volumes``,
                 ``file_system_snapshot``, ``image_pull_credentials``,
-                ``security_context``, ``working_dir``) also
-                require ``container_image``:
+                ``security_context``, ``working_dir``) require
+                ``container_image`` unless ``containers=`` replaces the list:
                 the API replaces the whole container list and rejects a
                 sparse patch. Session/default tags are merged and sent as a
                 replace-on-presence override so ``list()``/``adopt`` can find
@@ -2300,6 +2441,8 @@ class Sandbox:
         sandbox._dns_egress_names = ()
         sandbox._file_system_snapshot_id = None
         sandbox._file_system_snapshot_ids = ()
+        sandbox._spec_containers = ()
+        sandbox._container_statuses = ()
         sandbox._observed_file_op_cap_bytes = None
         sandbox._streaming_fallback_warned = False
         sandbox._start_lock = asyncio.Lock()
@@ -3303,6 +3446,20 @@ class Sandbox:
         return self._service_endpoints
 
     @property
+    def containers(self) -> tuple[Container, ...]:
+        """Create-time container spec echoed from the sandbox resource.
+
+        Empty until create/Get/list populates it. ``primary=True`` is filled
+        on the inferred primary so a clone of this list is a valid create.
+        """
+        return self._spec_containers
+
+    @property
+    def container_statuses(self) -> tuple[ContainerStatus, ...]:
+        """Per-container observed state. Sandbox ``status`` stays primary-owned."""
+        return self._container_statuses
+
+    @property
     def dns_egress_names(self) -> tuple[str, ...]:
         """Hostnames granted at create, echoed from ``status.effective_egress``.
 
@@ -4098,82 +4255,168 @@ class Sandbox:
                 raise translated from e
         raise AssertionError("unreachable: placement spillover loop exited without return")
 
+    def _apply_resource_options(self, container: sandbox_pb2.Container, resources_opt: Any) -> None:
+        if resources_opt is None:
+            return
+        if not isinstance(resources_opt, ResourceOptions):
+            resources_opt = normalize_resources(resources_opt)
+        if resources_opt is None:
+            return
+        reqs = self._resources_to_proto(resources_opt.requests, resources_opt.gpu)
+        lims = self._resources_to_proto(resources_opt.limits, resources_opt.gpu)
+        if reqs is not None or lims is not None:
+            container.resource_requirements.CopyFrom(
+                sandbox_pb2.ResourceRequirements(
+                    requests=reqs or sandbox_pb2.Resources(),
+                    limits=lims or sandbox_pb2.Resources(),
+                )
+            )
+
+    @staticmethod
+    def _apply_secrets(container: sandbox_pb2.Container, secrets: Any) -> None:
+        if not secrets:
+            return
+        grouped: dict[str, list[dict[str, str]]] = {}
+        for secret in secrets:
+            if not isinstance(secret, Secret):
+                secret = Secret(**secret)
+            grouped.setdefault(secret.store, []).append(
+                {
+                    "path": secret.name,
+                    "field": secret.field,
+                    "env_var": secret.env_var or secret.name,
+                }
+            )
+        for store, mappings in grouped.items():
+            container.secret_stores.append(
+                sandbox_pb2.SecretStoreReference(store_name=store, secrets=mappings)
+            )
+
+    @staticmethod
+    def _apply_image_pull_credentials(container: sandbox_pb2.Container, ipc: Any) -> None:
+        if ipc is None:
+            return
+        if isinstance(ipc, dict):
+            ipc = ImagePullCredentials(**ipc)
+        container.image_pull_credentials.CopyFrom(
+            sandbox_pb2.ImagePullCredentials(
+                registry=ipc.registry,
+                credentials=sandbox_pb2.SecretSource(
+                    store_name=ipc.store, path=ipc.name, field=ipc.field
+                ),
+            )
+        )
+
+    @staticmethod
+    def _apply_mounted_files(container: sandbox_pb2.Container, mounted_files: Any) -> None:
+        if not mounted_files:
+            return
+        entries = (
+            (
+                {"mount_path": path, "file_content": content}
+                for path, content in mounted_files.items()
+            )
+            if isinstance(mounted_files, Mapping)
+            else iter(mounted_files)
+        )
+        for entry in entries:
+            path = entry["mount_path"]
+            content = entry["file_content"]
+            data = content if isinstance(content, (bytes, bytearray)) else str(content).encode()
+            container.files.append(sandbox_pb2.FileMount(path=path, content=bytes(data)))
+
+    @staticmethod
+    def _volume_mount_to_proto(mount: VolumeMount) -> sandbox_pb2.VolumeMount:
+        proto = sandbox_pb2.VolumeMount(volume=mount.volume, mount_path=mount.mount_path)
+        if mount.read_only:
+            proto.read_only = True
+        if mount.sub_path:
+            proto.sub_path = mount.sub_path
+        return proto
+
+    def _user_container_to_proto(self, row: Container) -> sandbox_pb2.Container:
+        container = sandbox_pb2.Container(image=row.image)
+        if row.name:
+            container.name = row.name
+        if row.command:
+            container.command = row.command
+        if row.args:
+            container.args.extend(row.args)
+        if row.environment_variables:
+            container.environment_variables.update(row.environment_variables)
+        if row.working_dir:
+            container.working_dir = row.working_dir
+        if row.primary:
+            container.primary = True
+        self._apply_resource_options(container, row.resources)
+        self._apply_secrets(container, row.secrets)
+        self._apply_image_pull_credentials(container, row.image_pull_credentials)
+        self._apply_mounted_files(container, row.mounted_files)
+        for mount in row.volume_mounts or ():
+            container.volume_mounts.append(self._volume_mount_to_proto(_coerce_volume_mount(mount)))
+        return container
+
+    @staticmethod
+    def _append_unique_mounts(
+        container: sandbox_pb2.Container, mounts: Sequence[sandbox_pb2.VolumeMount]
+    ) -> None:
+        existing = {(mount.volume, mount.mount_path) for mount in container.volume_mounts}
+        for mount in mounts:
+            key = (mount.volume, mount.mount_path)
+            if key not in existing:
+                container.volume_mounts.append(mount)
+                existing.add(key)
+
+    @staticmethod
+    def _primary_index(containers: Sequence[sandbox_pb2.Container]) -> int:
+        for index, row in enumerate(containers):
+            if row.HasField("primary") and row.primary:
+                return index
+        return 0
+
+    @staticmethod
+    def _container_to_partial(container: sandbox_pb2.Container) -> sandbox_pb2.PartialContainer:
+        partial = sandbox_pb2.PartialContainer()
+        partial.ParseFromString(container.SerializeToString())
+        return partial
+
     def _build_create_request(
         self, *, request_id: str, start_kwargs: dict[str, Any]
     ) -> sandbox_pb2.CreateSandboxRequest:
         """Build a v1 CreateSandboxRequest from constructor/start kwargs."""
-        container = sandbox_pb2.Container(
-            name="main",
-            image=self._container_image,
-            command=self._command,
-            args=list(self._args or []),
-            primary=True,
-        )
-        if self._environment_variables:
-            container.environment_variables.update(self._environment_variables)
-
-        resources_opt = start_kwargs.pop("resources", None)
-        if resources_opt is not None:
-            if not isinstance(resources_opt, ResourceOptions):
-                resources_opt = normalize_resources(resources_opt)
-            if resources_opt is not None:
-                reqs = self._resources_to_proto(resources_opt.requests, resources_opt.gpu)
-                lims = self._resources_to_proto(resources_opt.limits, resources_opt.gpu)
-                if reqs is not None or lims is not None:
-                    container.resource_requirements.CopyFrom(
-                        sandbox_pb2.ResourceRequirements(
-                            requests=reqs or sandbox_pb2.Resources(),
-                            limits=lims or sandbox_pb2.Resources(),
-                        )
-                    )
-
-        secrets = start_kwargs.pop("secrets", None)
-        if secrets:
-            grouped: dict[str, list[dict[str, str]]] = {}
-            for s in secrets:
-                if not isinstance(s, Secret):
-                    s = Secret(**s)
-                grouped.setdefault(s.store, []).append(
-                    {"path": s.name, "field": s.field, "env_var": s.env_var or s.name}
-                )
-            for store, mappings in grouped.items():
-                container.secret_stores.append(
-                    sandbox_pb2.SecretStoreReference(store_name=store, secrets=mappings)
-                )
-
-        ipc = start_kwargs.pop("image_pull_credentials", None) or self._image_pull_credentials
-        if ipc is not None:
-            if isinstance(ipc, dict):
-                ipc = ImagePullCredentials(**ipc)
-            container.image_pull_credentials.CopyFrom(
-                sandbox_pb2.ImagePullCredentials(
-                    registry=ipc.registry,
-                    credentials=sandbox_pb2.SecretSource(
-                        store_name=ipc.store, path=ipc.name, field=ipc.field
-                    ),
-                )
+        user_containers = start_kwargs.pop("containers", None)
+        proto_containers: list[sandbox_pb2.Container]
+        if user_containers:
+            proto_containers = [
+                self._user_container_to_proto(_coerce_container(row)) for row in user_containers
+            ]
+            start_kwargs.pop("resources", None)
+            start_kwargs.pop("secrets", None)
+            start_kwargs.pop("mounted_files", None)
+            start_kwargs.pop("image_pull_credentials", None)
+        else:
+            container = sandbox_pb2.Container(
+                name="main",
+                image=self._container_image,
+                command=self._command,
+                args=list(self._args or []),
             )
-
-        if self._working_dir:
-            container.working_dir = self._working_dir
-        if self._security_context is not None:
-            container.security_context.CopyFrom(security_context_to_proto(self._security_context))
-
-        mounted_files = start_kwargs.pop("mounted_files", None)
-        if mounted_files:
-            entries = (
-                (
-                    {"mount_path": path, "file_content": content}
-                    for path, content in mounted_files.items()
+            if self._working_dir:
+                container.working_dir = self._working_dir
+            if self._security_context is not None:
+                container.security_context.CopyFrom(
+                    security_context_to_proto(self._security_context)
                 )
-                if isinstance(mounted_files, Mapping)
-                else iter(mounted_files)
+            if self._environment_variables:
+                container.environment_variables.update(self._environment_variables)
+            self._apply_resource_options(container, start_kwargs.pop("resources", None))
+            self._apply_secrets(container, start_kwargs.pop("secrets", None))
+            self._apply_image_pull_credentials(
+                container,
+                start_kwargs.pop("image_pull_credentials", None) or self._image_pull_credentials,
             )
-            for entry in entries:
-                path = entry["mount_path"]
-                content = entry["file_content"]
-                data = content if isinstance(content, (bytes, bytearray)) else str(content).encode()
-                container.files.append(sandbox_pb2.FileMount(path=path, content=bytes(data)))
+            self._apply_mounted_files(container, start_kwargs.pop("mounted_files", None))
+            proto_containers = [container]
 
         volumes: list[sandbox_pb2.SandboxVolume] = []
         mounts: list[sandbox_pb2.VolumeMount] = []
@@ -4189,20 +4432,23 @@ class Sandbox:
                 fss_opts = FileSystemSnapshotOptions(**fss_opts)
             scratch_opts = fss_opts.to_scratch_volume()
             volumes.append(scratch_volume_to_proto(scratch_opts))
-            mounts.append(
-                volume_mount_to_proto(
-                    scratch_opts.name,
-                    scratch_opts.mount_path,
-                    sub_path=scratch_opts.sub_path,
-                    read_only=scratch_opts.read_only,
+            if scratch_opts.mount_path:
+                mounts.append(
+                    volume_mount_to_proto(
+                        scratch_opts.name,
+                        scratch_opts.mount_path,
+                        sub_path=scratch_opts.sub_path,
+                        read_only=scratch_opts.read_only,
+                    )
                 )
-            )
             self._scratch_volume_names = tuple(
                 list(self._scratch_volume_names) + [scratch_opts.name]
             )
 
-        for mount in mounts:
-            container.volume_mounts.append(mount)
+        if proto_containers and mounts:
+            self._append_unique_mounts(
+                proto_containers[self._primary_index(proto_containers)], mounts
+            )
 
         services_arg = start_kwargs.pop("services", None) or self._services
         services: list[sandbox_pb2.Service] = []
@@ -4293,7 +4539,7 @@ class Sandbox:
             mode = sandbox_pb2.SANDBOX_MODE_CKS
 
         spec = sandbox_pb2.SandboxSpec(
-            containers=[container],
+            containers=proto_containers,
             volumes=volumes,
             services=services,
             tags=list(self._tags or []),
@@ -4337,7 +4583,8 @@ class Sandbox:
             request_id=request_id, start_kwargs=dict(overrides_kwargs)
         )
         spec = create_req.sandbox.spec
-        source_container = spec.containers[0]
+        source_container = spec.containers[0] if spec.containers else sandbox_pb2.Container()
+        containers_override = "containers" in explicit_keys
         container_field_overrides = (
             self._command is not None
             or self._args is not None
@@ -4349,18 +4596,16 @@ class Sandbox:
             or self._image_pull_credentials is not None
             or self._security_context is not None
             or self._working_dir is not None
+            or containers_override
         )
-        if container_field_overrides and self._container_image is None:
+        if container_field_overrides and self._container_image is None and not containers_override:
             raise TypeError(
                 "replace-on-presence container overrides require container_image; "
                 "the API replaces the whole container list and rejects sparse patches"
             )
-        if self._container_image is not None:
-            if self._args is not None and self._command is None:
-                raise TypeError(
-                    "container overrides with args require command; "
-                    "the API rejects args without command after a whole-list container replace"
-                )
+        if containers_override:
+            override_containers = [self._container_to_partial(row) for row in spec.containers]
+        elif self._container_image is not None:
             container = sandbox_pb2.PartialContainer(
                 name="main",
                 image=self._container_image,
@@ -4387,12 +4632,13 @@ class Sandbox:
                 container.security_context.CopyFrom(
                     security_context_to_proto(self._security_context)
                 )
+            override_containers = [container]
         else:
-            container = sandbox_pb2.PartialContainer()
+            override_containers = []
 
         overrides = sandbox_pb2.PartialSandboxSpec()
-        if self._container_image is not None:
-            overrides.containers.append(container)
+        if override_containers:
+            overrides.containers.extend(override_containers)
         if {"volumes", "file_system_snapshot"} & explicit_keys:
             overrides.volumes.extend(spec.volumes)
         if self._services:
@@ -4514,6 +4760,84 @@ class Sandbox:
             self._resource_limits = self._resources_from_proto(status.effective_resources)
             self._resource_requests = self._resource_limits
             self._resource_gpu = self._gpu_from_proto(status.effective_resources)
+        echoed = tuple(self._container_from_proto(row) for row in view._sandbox.spec.containers)
+        if echoed and not any(row.primary for row in echoed):
+            echoed = (replace(echoed[0], primary=True),) + echoed[1:]
+        self._spec_containers = echoed
+        self._container_statuses = tuple(
+            ContainerStatus(
+                name=row.name,
+                state=SandboxStatus.from_proto(row.state),
+                exit_code=row.exit_code,
+                restart_count=row.restart_count,
+            )
+            for row in status.container_statuses
+        )
+
+    def _container_from_proto(self, proto: sandbox_pb2.Container) -> Container:
+        resources: ResourceOptions | None = None
+        if proto.HasField("resource_requirements"):
+            rr = proto.resource_requirements
+            gpu = None
+            requests = self._resources_from_proto(rr.requests) if rr.HasField("requests") else None
+            limits = self._resources_from_proto(rr.limits) if rr.HasField("limits") else None
+            if rr.HasField("requests"):
+                gpu = self._gpu_from_proto(rr.requests)
+            if gpu is None and rr.HasField("limits"):
+                gpu = self._gpu_from_proto(rr.limits)
+            if requests or limits or gpu:
+                resources = ResourceOptions(requests=requests, limits=limits, gpu=gpu)
+        elif proto.HasField("resources"):
+            cpu_mem = self._resources_from_proto(proto.resources)
+            gpu = self._gpu_from_proto(proto.resources)
+            if cpu_mem or gpu:
+                resources = ResourceOptions(requests=cpu_mem, limits=cpu_mem, gpu=gpu)
+        secrets = tuple(
+            Secret(
+                store=store.store_name,
+                name=mapping.path,
+                field=mapping.field,
+                env_var=mapping.env_var or None,
+            )
+            for store in proto.secret_stores
+            for mapping in store.secrets
+        )
+        mounts = tuple(
+            VolumeMount(
+                volume=mount.volume,
+                mount_path=mount.mount_path,
+                read_only=mount.read_only,
+                sub_path=mount.sub_path or None,
+            )
+            for mount in proto.volume_mounts
+        )
+        files = tuple(
+            {"mount_path": file_mount.path, "file_content": bytes(file_mount.content)}
+            for file_mount in proto.files
+        )
+        ipc = None
+        if proto.HasField("image_pull_credentials"):
+            creds = proto.image_pull_credentials
+            ipc = ImagePullCredentials(
+                registry=creds.registry,
+                store=creds.credentials.store_name,
+                name=creds.credentials.path,
+                field=creds.credentials.field,
+            )
+        return Container(
+            image=proto.image,
+            name=proto.name or None,
+            command=proto.command or None,
+            args=tuple(proto.args) or None,
+            environment_variables=dict(proto.environment_variables) or None,
+            resources=resources,
+            mounted_files=files or None,
+            volume_mounts=mounts or None,
+            secrets=secrets or None,
+            working_dir=proto.working_dir or None,
+            image_pull_credentials=ipc,
+            primary=proto.HasField("primary") and proto.primary,
+        )
 
     @staticmethod
     def _resources_from_proto(res: sandbox_pb2.Resources) -> dict[str, str] | None:
@@ -5623,6 +5947,7 @@ class Sandbox:
         since_time: datetime | None = None,
         timestamps: bool = False,
         timeout_seconds: float | None = None,
+        container: str | None = None,
     ) -> None:
         """Stream PID-1 logs via v1 unary StreamLogs → LogEntry server stream."""
         inner_exit_clean = False
@@ -5666,6 +5991,7 @@ class Sandbox:
                     sandbox_id=sandbox_id,
                     follow=follow,
                 )
+                _set_request_container(request, container)
                 if is_resume:
                     request.resume_log_session_id = session_id
                     request.resume_log_offset = last_offset
@@ -5891,6 +6217,7 @@ class Sandbox:
         resize_queue: asyncio.Queue[tuple[int, int] | None],
         tty_width: int | None = None,
         tty_height: int | None = None,
+        container: str | None = None,
     ) -> TerminalResult:
         """Internal async: Execute TTY command, push raw bytes to output queue.
 
@@ -5935,6 +6262,7 @@ class Sandbox:
                     command=list(command),
                     tty=True,
                 )
+                _set_request_container(init_msg, container)
                 if tty_width is not None:
                     init_msg.tty_width = tty_width
                 if tty_height is not None:
@@ -6128,6 +6456,7 @@ class Sandbox:
         timeout_seconds: float | None = None,
         stdin_queue: asyncio.Queue[bytes | None] | None = None,
         stdin_writer: StreamWriter | None = None,
+        container: str | None = None,
     ) -> ProcessResult:
         """Internal async: Execute command using StreamExec RPC, push output to queues.
 
@@ -6182,12 +6511,12 @@ class Sandbox:
             which signals gRPC to half-close the send direction.
             """
             # Yield init message first
-            yield sandbox_pb2.ExecStreamRequest(
-                init=sandbox_pb2.ExecStreamInit(
-                    sandbox_id=sandbox_id,
-                    command=rpc_command,
-                )
+            init_msg = sandbox_pb2.ExecStreamInit(
+                sandbox_id=sandbox_id,
+                command=rpc_command,
             )
+            _set_request_container(init_msg, container)
+            yield sandbox_pb2.ExecStreamRequest(init=init_msg)
 
             # If stdin is enabled, wait for ready signal before sending data
             if stdin_queue is not None:
@@ -6399,6 +6728,7 @@ class Sandbox:
         check: bool = False,
         timeout_seconds: float | None = None,
         stdin: bool = False,
+        container: str | None = None,
     ) -> Process:
         """Execute command, return Process immediately.
 
@@ -6416,6 +6746,7 @@ class Sandbox:
             stdin: If True, enable stdin streaming. Process.stdin will be a
                 StreamWriter that can send input to the command. If False (default),
                 stdin is closed immediately and Process.stdin is None.
+            container: Container name to exec into. Empty/None targets the primary.
 
         Returns:
             Process handle with streaming stdout/stderr. Call .result() to block
@@ -6481,6 +6812,7 @@ class Sandbox:
                 timeout_seconds=timeout_seconds,
                 stdin_queue=stdin_queue,
                 stdin_writer=stdin_writer,
+                container=container,
             )
         )
 
@@ -6499,6 +6831,7 @@ class Sandbox:
         *,
         width: int | None = None,
         height: int | None = None,
+        container: str | None = None,
     ) -> TerminalSession:
         """Start an interactive TTY session in the sandbox.
 
@@ -6511,6 +6844,8 @@ class Sandbox:
                 Accepts a sequence like ["/bin/sh"] or ["/usr/bin/python3"].
             width: Initial terminal width in columns.
             height: Initial terminal height in rows.
+            container: Container name for the TTY session. Empty/None targets
+                the primary.
 
         Returns:
             TerminalSession handle with .output (StreamReader[bytes]),
@@ -6557,6 +6892,7 @@ class Sandbox:
                 resize_queue=resize_queue,
                 tty_width=width,
                 tty_height=height,
+                container=container,
             )
         )
 
@@ -6586,6 +6922,7 @@ class Sandbox:
         operation: str,
         filepath: str | None = None,
         _retry_retiring: bool = True,
+        container: str | None = None,
     ) -> tuple[int, bytes, bytes]:
         """Run one non-TTY StreamExec and return raw stdout/stderr bytes.
 
@@ -6620,12 +6957,12 @@ class Sandbox:
         request_error: Exception | None = None
 
         async def request_generator() -> AsyncIterator[sandbox_pb2.ExecStreamRequest]:
-            yield sandbox_pb2.ExecStreamRequest(
-                init=sandbox_pb2.ExecStreamInit(
-                    sandbox_id=sandbox_id,
-                    command=list(command),
-                )
+            init_msg = sandbox_pb2.ExecStreamInit(
+                sandbox_id=sandbox_id,
+                command=list(command),
             )
+            _set_request_container(init_msg, container)
+            yield sandbox_pb2.ExecStreamRequest(init=init_msg)
 
             if stdin is None:
                 return
@@ -6751,6 +7088,7 @@ class Sandbox:
                 operation=operation,
                 filepath=filepath,
                 _retry_retiring=False,
+                container=container,
             )
 
         if request_error is not None:
@@ -6768,11 +7106,14 @@ class Sandbox:
             b"".join(stderr_buffer),
         )
 
-    async def _read_file_unary_async(self, filepath: str, timeout: float) -> bytes:
+    async def _read_file_unary_async(
+        self, filepath: str, timeout: float, *, container: str | None = None
+    ) -> bytes:
         request = sandbox_pb2.ReadFileRequest(
             sandbox_id=self._sandbox_id,
             path=filepath,
         )
+        _set_request_container(request, container)
         for attempt in range(2):
             prepared = await self._prepare_data_plane_call(
                 sandbox_pb2.SANDBOX_DATA_PERMISSION_READ_FILE,
@@ -6801,7 +7142,12 @@ class Sandbox:
         raise AssertionError("unreachable")
 
     async def _read_file_via_exec_streaming(
-        self, filepath: str, timeout: float, *, expected_size: int | None = None
+        self,
+        filepath: str,
+        timeout: float,
+        *,
+        expected_size: int | None = None,
+        container: str | None = None,
     ) -> bytes:
         script = (
             "path=$1\n"
@@ -6820,6 +7166,7 @@ class Sandbox:
             timeout_seconds=timeout,
             operation="Read file",
             filepath=filepath,
+            container=container,
         )
         if returncode != 0:
             detail = stderr.decode("utf-8", errors="replace").strip()
@@ -6857,7 +7204,9 @@ class Sandbox:
         )
         return stdout
 
-    async def _stat_file_size_async(self, filepath: str, timeout: float) -> int | None:
+    async def _stat_file_size_async(
+        self, filepath: str, timeout: float, *, container: str | None = None
+    ) -> int | None:
         """Best-effort: ask the sandbox for the file's size in bytes.
 
         Returns ``None`` if the size could not be determined (stat unavailable,
@@ -6872,6 +7221,7 @@ class Sandbox:
                 timeout_seconds=timeout,
                 operation="Stat file size",
                 filepath=filepath,
+                container=container,
             )
         except Exception:
             return None
@@ -6958,6 +7308,8 @@ class Sandbox:
         self,
         filepath: str,
         timeout: float,
+        *,
+        container: str | None = None,
     ) -> bytes:
         """Internal async: Read a file from the sandbox filesystem."""
         await self._ensure_started_async()
@@ -6975,7 +7327,7 @@ class Sandbox:
         logger.debug("Reading file from sandbox %s: %s", self._sandbox_id, filepath)
 
         try:
-            return await self._read_file_unary_async(filepath, timeout)
+            return await self._read_file_unary_async(filepath, timeout, container=container)
         except SandboxFileError as e:
             if e.reason != CWSANDBOX_FILE_TOO_LARGE:
                 raise
@@ -6993,7 +7345,9 @@ class Sandbox:
             # ``size`` is the server-reported pre-read size: feed it to the
             # truncation check directly, so the fallback needs no extra stat
             # round-trip and cannot false-positive on a growing file.
-            return await self._read_file_via_exec_streaming(filepath, timeout, expected_size=size)
+            return await self._read_file_via_exec_streaming(
+                filepath, timeout, expected_size=size, container=container
+            )
         except SandboxResourceExhaustedError:
             # Backend resource pressure is indistinguishable from message-size
             # rejects on this code path without inspecting error text; remote
@@ -7007,19 +7361,21 @@ class Sandbox:
                 self._sandbox_id,
                 filepath,
             )
-            return await self._read_file_via_exec_streaming(filepath, timeout)
+            return await self._read_file_via_exec_streaming(filepath, timeout, container=container)
 
     def read_file(
         self,
         filepath: str,
         *,
         timeout_seconds: float | None = None,
+        container: str | None = None,
     ) -> OperationRef[bytes]:
         """Read file from sandbox, return OperationRef immediately.
 
         Args:
             filepath: Path to file in sandbox
             timeout_seconds: Timeout for the operation
+            container: Container to read from. Empty/None targets the primary.
 
         Returns:
             OperationRef[bytes]: Use .result() to block and retrieve contents.
@@ -7055,7 +7411,9 @@ class Sandbox:
             ```
         """
         timeout = timeout_seconds if timeout_seconds is not None else self._request_timeout_seconds
-        future = self._loop_manager.run_async(self._read_file_async(filepath, timeout))
+        future = self._loop_manager.run_async(
+            self._read_file_async(filepath, timeout, container=container)
+        )
         return OperationRef(future)
 
     async def _write_file_unary_async(
@@ -7063,12 +7421,15 @@ class Sandbox:
         filepath: str,
         contents: bytes,
         timeout: float,
+        *,
+        container: str | None = None,
     ) -> None:
         request = sandbox_pb2.WriteFileRequest(
             sandbox_id=self._sandbox_id,
             path=filepath,
             content=contents,
         )
+        _set_request_container(request, container)
         for attempt in range(2):
             prepared = await self._prepare_data_plane_call(
                 sandbox_pb2.SANDBOX_DATA_PERMISSION_WRITE_FILE,
@@ -7102,6 +7463,8 @@ class Sandbox:
         filepath: str,
         contents: bytes,
         timeout: float,
+        *,
+        container: str | None = None,
     ) -> None:
         script = (
             "path=$1\n"
@@ -7126,6 +7489,7 @@ class Sandbox:
                 timeout_seconds=timeout,
                 operation="Write file",
                 filepath=filepath,
+                container=container,
             )
         except SandboxStreamBackpressureError:
             # A too-slow producer is its own actionable, typed failure. Let it
@@ -7244,6 +7608,8 @@ class Sandbox:
         filepath: str,
         contents: bytes,
         timeout: float,
+        *,
+        container: str | None = None,
     ) -> None:
         """Internal async: Write a file to the sandbox filesystem."""
         await self._ensure_started_async()
@@ -7288,11 +7654,13 @@ class Sandbox:
             self._notify_streaming_fallback_once(
                 "Write file", filepath, size, suggest_method="write_file_streaming"
             )
-            await self._write_file_via_exec_streaming(filepath, contents, timeout)
+            await self._write_file_via_exec_streaming(
+                filepath, contents, timeout, container=container
+            )
             return
 
         try:
-            await self._write_file_unary_async(filepath, contents, timeout)
+            await self._write_file_unary_async(filepath, contents, timeout, container=container)
         except SandboxFileError as e:
             if e.reason != CWSANDBOX_FILE_TOO_LARGE:
                 raise
@@ -7302,7 +7670,9 @@ class Sandbox:
             self._notify_streaming_fallback_once(
                 "Write file", filepath, size, suggest_method="write_file_streaming"
             )
-            await self._write_file_via_exec_streaming(filepath, contents, timeout)
+            await self._write_file_via_exec_streaming(
+                filepath, contents, timeout, container=container
+            )
         except SandboxResourceExhaustedError as e:
             # Legacy gRPC frame-size signal. Distinguishable from real backend
             # pressure only by message text, so the fallback fires only on the
@@ -7315,7 +7685,9 @@ class Sandbox:
                 self._sandbox_id,
                 filepath,
             )
-            await self._write_file_via_exec_streaming(filepath, contents, timeout)
+            await self._write_file_via_exec_streaming(
+                filepath, contents, timeout, container=container
+            )
 
     def write_file(
         self,
@@ -7323,6 +7695,7 @@ class Sandbox:
         contents: bytes,
         *,
         timeout_seconds: float | None = None,
+        container: str | None = None,
     ) -> OperationRef[None]:
         """Write file to sandbox, return OperationRef immediately.
 
@@ -7330,6 +7703,7 @@ class Sandbox:
             filepath: Path to file in sandbox
             contents: File contents as bytes
             timeout_seconds: Timeout for the operation
+            container: Container to write into. Empty/None targets the primary.
 
         Returns:
             OperationRef[None]: Use .result() to block until complete.
@@ -7356,7 +7730,9 @@ class Sandbox:
             ```
         """
         timeout = timeout_seconds if timeout_seconds is not None else self._request_timeout_seconds
-        future = self._loop_manager.run_async(self._write_file_async(filepath, contents, timeout))
+        future = self._loop_manager.run_async(
+            self._write_file_async(filepath, contents, timeout, container=container)
+        )
         return OperationRef(future)
 
     async def _write_file_streaming_async(
@@ -7364,6 +7740,8 @@ class Sandbox:
         filepath: str,
         source: bytes | Iterable[bytes] | AsyncIterable[bytes],
         timeout: float,
+        *,
+        container: str | None = None,
     ) -> None:
         await self._ensure_started_async()
         if self._is_done or self._is_stopping:
@@ -7405,6 +7783,7 @@ class Sandbox:
                 timeout_seconds=timeout,
                 operation="Stream write file",
                 filepath=filepath,
+                container=container,
             )
         except SandboxStreamBackpressureError:
             # A too-slow producer is its own actionable failure — surface the
@@ -7440,6 +7819,7 @@ class Sandbox:
         source: bytes | Iterable[bytes] | AsyncIterable[bytes],
         *,
         timeout_seconds: float | None = None,
+        container: str | None = None,
     ) -> OperationRef[None]:
         """Stream a file to the sandbox without materializing the full payload.
 
@@ -7477,7 +7857,7 @@ class Sandbox:
         """
         timeout = timeout_seconds if timeout_seconds is not None else self._request_timeout_seconds
         future = self._loop_manager.run_async(
-            self._write_file_streaming_async(filepath, source, timeout)
+            self._write_file_streaming_async(filepath, source, timeout, container=container)
         )
         return OperationRef(future)
 
@@ -7487,6 +7867,8 @@ class Sandbox:
         output_queue: asyncio.Queue[bytes | Exception | None],
         timeout: float,
         _retry_retiring: bool = True,
+        *,
+        container: str | None = None,
     ) -> None:
         try:
             # Absolute wall-clock deadline for the whole operation (stat + read),
@@ -7510,7 +7892,9 @@ class Sandbox:
             # never look like a short read (issue #1172 false-positive fix). The
             # stat draws from the operation's remaining budget, capped short
             # because it is an O(1) metadata lookup.
-            expected_size = await self._stat_file_size_async(filepath, self._stat_budget(deadline))
+            expected_size = await self._stat_file_size_async(
+                filepath, self._stat_budget(deadline), container=container
+            )
 
             prepared = await self._prepare_streaming_call()
             stub = prepared.stub
@@ -7526,12 +7910,12 @@ class Sandbox:
                 # stdin close is unnecessary and can race server-side stream
                 # setup. The request stream half-closes when this generator
                 # returns, matching the stdin-less exec path.
-                yield sandbox_pb2.ExecStreamRequest(
-                    init=sandbox_pb2.ExecStreamInit(
-                        sandbox_id=sandbox_id,
-                        command=["/bin/cat", "--", filepath],
-                    )
+                init_msg = sandbox_pb2.ExecStreamInit(
+                    sandbox_id=sandbox_id,
+                    command=["/bin/cat", "--", filepath],
                 )
+                _set_request_container(init_msg, container)
+                yield sandbox_pb2.ExecStreamRequest(init=init_msg)
 
             # The read gets the budget remaining after the pre-read stat, so the
             # two phases together honor the caller's overall timeout.
@@ -7596,6 +7980,7 @@ class Sandbox:
                         output_queue,
                         timeout if retry_budget is None else retry_budget,
                         _retry_retiring=False,
+                        container=container,
                     )
                     return
                 raise SandboxTimeoutError(f"Timed out reading file '{filepath}'")
@@ -7652,6 +8037,7 @@ class Sandbox:
         filepath: str,
         *,
         timeout_seconds: float | None = None,
+        container: str | None = None,
     ) -> StreamReader[bytes]:
         """Stream a file from the sandbox in chunks without buffering the whole payload.
 
@@ -7712,7 +8098,7 @@ class Sandbox:
             maxsize=STREAMING_OUTPUT_QUEUE_SIZE
         )
         future = self._loop_manager.run_async(
-            self._read_file_streaming_async(filepath, output_queue, timeout)
+            self._read_file_streaming_async(filepath, output_queue, timeout, container=container)
         )
         reader = StreamReader(
             output_queue,
@@ -7733,6 +8119,7 @@ class Sandbox:
         since_time: datetime | None = None,
         timestamps: bool = False,
         timeout_seconds: float | None = None,
+        container: str | None = None,
     ) -> StreamReader[str]:
         """Stream logs from the sandbox's main process.
 
@@ -7764,6 +8151,8 @@ class Sandbox:
             timeout_seconds: Client-side deadline for the gRPC call. Defaults
                 to ``request_timeout_seconds`` when ``follow=False``, and
                 ``None`` (no timeout) when ``follow=True``.
+            container: Container whose logs to stream. Empty/None targets the
+                primary.
 
         Returns:
             StreamReader yielding log lines as strings. Iterate synchronously
@@ -7809,6 +8198,7 @@ class Sandbox:
                 since_time=since_time,
                 timestamps=timestamps,
                 timeout_seconds=timeout_seconds,
+                container=container,
             )
         )
 

--- a/src/cwsandbox/_session.py
+++ b/src/cwsandbox/_session.py
@@ -15,6 +15,7 @@ from cwsandbox._defaults import DEFAULT_BASE_URL, SandboxDefaults, _resolve_sele
 from cwsandbox._function import RemoteFunction
 from cwsandbox._loop_manager import _LoopManager
 from cwsandbox._types import (
+    Container,
     DataPlaneMode,
     ExecOutcome,
     FileSystemSnapshotOptions,
@@ -364,6 +365,7 @@ class Session:
         request_timeout_seconds: float | None = None,
         data_plane_mode: DataPlaneMode | str | None = None,
         auth: AuthConfig | None = None,
+        containers: Sequence[Container | Mapping[str, Any]] | None = None,
         **kwargs: Any,
     ) -> Sandbox:
         """Create an unstarted sandbox with session defaults.
@@ -411,6 +413,8 @@ class Session:
                 Use for non-sensitive metadata only.
             secrets: Secrets to inject as environment variables.
                 Merged with session defaults (defaults first, then this list).
+            containers: Multi-container spec. Mutually exclusive with
+                single-container kwargs. Not used by ``@session.function()``.
 
         Returns:
             An unstarted Sandbox registered with the session.
@@ -487,6 +491,7 @@ class Session:
             request_timeout_seconds=effective_request_timeout,
             data_plane_mode=data_plane_mode,
             auth=auth,
+            containers=containers,
             defaults=self._defaults,
             _session=self,
         )

--- a/src/cwsandbox/_session.py
+++ b/src/cwsandbox/_session.py
@@ -414,7 +414,10 @@ class Session:
             secrets: Secrets to inject as environment variables.
                 Merged with session defaults (defaults first, then this list).
             containers: Multi-container spec. Mutually exclusive with
-                single-container kwargs. Not used by ``@session.function()``.
+                single-container kwargs. Replaces session
+                ``defaults.secrets``, ``environment_variables``,
+                ``security_context``, and ``working_dir``; put those on
+                each ``Container``. Not used by ``@session.function()``.
 
         Returns:
             An unstarted Sandbox registered with the session.

--- a/src/cwsandbox/_spec.py
+++ b/src/cwsandbox/_spec.py
@@ -109,19 +109,21 @@ def volumes_to_proto(
         vol = _coerce_volume_options(raw)
         if isinstance(vol, ScratchVolumeOptions):
             volumes.append(scratch_volume_to_proto(vol))
-            mounts.append(
-                volume_mount_to_proto(
-                    vol.name, vol.mount_path, sub_path=vol.sub_path, read_only=vol.read_only
+            if vol.mount_path:
+                mounts.append(
+                    volume_mount_to_proto(
+                        vol.name, vol.mount_path, sub_path=vol.sub_path, read_only=vol.read_only
+                    )
                 )
-            )
             scratch_names.append(vol.name)
         else:
             volumes.append(sandbox_pb2.SandboxVolume(name=vol.name, volume_id=vol.volume_id))
-            mounts.append(
-                volume_mount_to_proto(
-                    vol.name, vol.mount_path, sub_path=vol.sub_path, read_only=vol.read_only
+            if vol.mount_path:
+                mounts.append(
+                    volume_mount_to_proto(
+                        vol.name, vol.mount_path, sub_path=vol.sub_path, read_only=vol.read_only
+                    )
                 )
-            )
     return volumes, mounts, tuple(scratch_names)
 
 

--- a/src/cwsandbox/_types.py
+++ b/src/cwsandbox/_types.py
@@ -1134,7 +1134,9 @@ class Container:
     Pass a list to ``Sandbox.run(containers=[...])``. That form is mutually
     exclusive with the single-container kwargs (``container_image``,
     ``command``/``args``, ``resources``, ``mounted_files``, ``secrets``,
-    ``image_pull_credentials``, ``environment_variables``).
+    ``image_pull_credentials``, ``environment_variables``,
+    ``security_context``, ``working_dir``) and does not inherit those
+    same fields from ``SandboxDefaults``.
 
     One container: ``primary`` may be omitted or False (that row is primary).
     More than one: exactly one row must set ``primary=True``, and every row
@@ -1172,14 +1174,17 @@ class Container:
     working_dir: str | None = None
     image_pull_credentials: ImagePullCredentials | Mapping[str, Any] | None = None
     primary: bool = False
+    # Status echo only. Create-time name/cwd/image checks do not apply to
+    # server-authored rows (reserved platform sidecars, working_dir="/").
+    _observed: bool = field(default=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:
-        if not self.image:
+        if not self.image and not self._observed:
             raise ValueError("Container.image cannot be empty")
         if self.name is not None:
             if not self.name:
                 object.__setattr__(self, "name", None)
-            else:
+            elif not self._observed:
                 _validate_container_name(self.name)
         if self.command is not None and not self.command:
             object.__setattr__(self, "command", None)
@@ -1196,7 +1201,7 @@ class Container:
         if self.working_dir is not None:
             if not self.working_dir:
                 object.__setattr__(self, "working_dir", None)
-            else:
+            elif not self._observed:
                 _validate_absolute_mount_path(self.working_dir, field="Container.working_dir")
         if self.volume_mounts is not None:
             object.__setattr__(
@@ -1222,6 +1227,15 @@ class Container:
             )
         if self.mounted_files is not None:
             object.__setattr__(self, "mounted_files", tuple(self.mounted_files))
+
+    @classmethod
+    def _from_observed(cls, **kwargs: Any) -> Container:
+        """Build a Container from a Get/list spec echo.
+
+        Skips reserved-name, DNS-1123, working_dir, and empty-image checks.
+        ``replace()`` keeps ``_observed`` so inferred ``primary`` stays valid.
+        """
+        return cls(_observed=True, **kwargs)
 
 
 def _coerce_container(value: Container | Mapping[str, Any]) -> Container:

--- a/src/cwsandbox/_types.py
+++ b/src/cwsandbox/_types.py
@@ -1079,6 +1079,24 @@ class Secret:
             raise ValueError("Secret.env_var cannot be empty")
 
 
+def _unique_secrets_by_env_var(secrets: Sequence[Secret]) -> tuple[Secret, ...]:
+    """Keep one secret per env_var; raise if two distinct sources conflict."""
+    seen: dict[str, Secret] = {}
+    for secret in secrets:
+        env_var = secret.env_var
+        assert env_var is not None  # guaranteed by Secret.__post_init__
+        if env_var in seen and secret != seen[env_var]:
+            raise ValueError(
+                f"Conflicting secrets for env_var {env_var!r}: "
+                f"Secret(store={seen[env_var].store!r}, name={seen[env_var].name!r}, "
+                f"field={seen[env_var].field!r}) vs "
+                f"Secret(store={secret.store!r}, name={secret.name!r}, "
+                f"field={secret.field!r})"
+            )
+        seen[env_var] = secret
+    return tuple(seen.values())
+
+
 @dataclass(frozen=True, kw_only=True)
 class ResourceOptions:
     """Resource configuration for sandbox CPU, memory, and GPU.
@@ -1166,7 +1184,13 @@ class Container:
         if self.command is not None and not self.command:
             object.__setattr__(self, "command", None)
         if self.args is not None:
-            object.__setattr__(self, "args", tuple(self.args))
+            if isinstance(self.args, (str, bytes)):
+                raise TypeError("Container.args must be a sequence of strings, not a string")
+            coerced_args = tuple(self.args)
+            for i, arg in enumerate(coerced_args):
+                if not isinstance(arg, str):
+                    raise TypeError(f"Container.args[{i}] must be str, got {type(arg).__name__}")
+            object.__setattr__(self, "args", coerced_args)
         if self.environment_variables is not None:
             object.__setattr__(self, "environment_variables", dict(self.environment_variables))
         if self.working_dir is not None:
@@ -1184,7 +1208,9 @@ class Container:
             object.__setattr__(
                 self,
                 "secrets",
-                tuple(s if isinstance(s, Secret) else Secret(**s) for s in self.secrets),
+                _unique_secrets_by_env_var(
+                    tuple(s if isinstance(s, Secret) else Secret(**s) for s in self.secrets)
+                ),
             )
         if self.image_pull_credentials is not None and not isinstance(
             self.image_pull_credentials, ImagePullCredentials

--- a/src/cwsandbox/_types.py
+++ b/src/cwsandbox/_types.py
@@ -318,12 +318,48 @@ class Service:
 
 # DNS-1123 subdomain, matching k8s IsDNS1123Subdomain used by the gateway.
 _DNS1123_LABEL = r"[a-z0-9](?:[-a-z0-9]*[a-z0-9])?"
+_DNS1123_LABEL_RE = re.compile(rf"^{_DNS1123_LABEL}$")
+_DNS1123_LABEL_MAX = 63
 _DNS1123_SUBDOMAIN_RE = re.compile(rf"^{_DNS1123_LABEL}(?:\.{_DNS1123_LABEL})*$")
 _DNS1123_SUBDOMAIN_MAX = 253
+
+# Closed reserved kubelet names (and restore- prefix) from the v1 multi-container contract.
+_RESERVED_CONTAINER_NAMES = frozenset(
+    {
+        "cw-object-store-agent",
+        "cw-object-store-agent-restore",
+        "dns-egress",
+        "dns-egress-probe",
+    }
+)
+_RESERVED_CONTAINER_NAME_PREFIX = "cw-object-store-agent-restore-"
 
 
 def _is_dns1123_subdomain(name: str) -> bool:
     return len(name) <= _DNS1123_SUBDOMAIN_MAX and _DNS1123_SUBDOMAIN_RE.fullmatch(name) is not None
+
+
+def _is_dns1123_label(name: str) -> bool:
+    return len(name) <= _DNS1123_LABEL_MAX and _DNS1123_LABEL_RE.fullmatch(name) is not None
+
+
+def _validate_absolute_mount_path(path: str, *, field: str) -> None:
+    if not path:
+        raise ValueError(f"{field} cannot be empty")
+    if not path.startswith("/"):
+        raise ValueError(f"{field} must be an absolute path, got: {path!r}")
+    if path == "/":
+        raise ValueError(f"{field} cannot be '/'")
+
+
+def _validate_container_name(name: str) -> None:
+    if not _is_dns1123_label(name):
+        raise ValueError(
+            "Container.name must be a DNS-1123 label (lowercase alphanumeric and "
+            f"hyphens, at most {_DNS1123_LABEL_MAX} characters), got: {name!r}"
+        )
+    if name in _RESERVED_CONTAINER_NAMES or name.startswith(_RESERVED_CONTAINER_NAME_PREFIX):
+        raise ValueError(f"Container.name {name!r} is reserved by the platform")
 
 
 class TenantScope(StrEnum):
@@ -679,9 +715,14 @@ def _coerce_string_sequence(value: Sequence[str] | None, *, field: str) -> tuple
 class ScratchVolumeOptions:
     """Named scratch volume for snapshot/restore workflows.
 
+    Volumes are sandbox-level. ``mount_path`` is a convenience that mounts
+    this volume on the primary container. For multi-container sandboxes,
+    omit ``mount_path`` and declare mounts on ``Container.volume_mounts``.
+
     Attributes:
         name: Volume name within the sandbox (referenced by mounts/snapshots).
-        mount_path: Absolute path to mount into the primary container.
+        mount_path: Absolute path to mount into the primary container. None
+            declares the volume without mounting it.
         size: Volume size (e.g. ``"10Gi"``). None uses the platform default.
         restore_from_snapshot_id: When set, restore this snapshot at create.
         medium: Backing store. Unset uses disk. ``MEMORY`` is tmpfs and
@@ -691,7 +732,7 @@ class ScratchVolumeOptions:
     """
 
     name: str
-    mount_path: str
+    mount_path: str | None = None
     size: str | None = None
     restore_from_snapshot_id: str | None = None
     medium: StorageMedium | str | None = None
@@ -701,14 +742,8 @@ class ScratchVolumeOptions:
     def __post_init__(self) -> None:
         if not self.name:
             raise ValueError("ScratchVolumeOptions.name cannot be empty")
-        if not self.mount_path:
-            raise ValueError("ScratchVolumeOptions.mount_path cannot be empty")
-        if not self.mount_path.startswith("/"):
-            raise ValueError(
-                f"ScratchVolumeOptions.mount_path must be absolute, got: {self.mount_path!r}"
-            )
-        if self.mount_path == "/":
-            raise ValueError("ScratchVolumeOptions.mount_path cannot be '/'")
+        if self.mount_path is not None:
+            _validate_absolute_mount_path(self.mount_path, field="ScratchVolumeOptions.mount_path")
         if self.size is not None and not self.size:
             object.__setattr__(self, "size", None)
         if self.restore_from_snapshot_id is not None and not self.restore_from_snapshot_id:
@@ -786,6 +821,40 @@ def _coerce_volume_options(
     raise TypeError(
         "volumes entries must be ScratchVolumeOptions, RegisteredVolumeOptions, "
         f"or dict, got {type(vol).__name__}"
+    )
+
+
+@dataclass(frozen=True, kw_only=True)
+class VolumeMount:
+    """Mount of a sandbox-level volume into one container.
+
+    Attributes:
+        volume: Name of a ``ScratchVolumeOptions`` / ``SandboxSpec`` volume.
+        mount_path: Absolute path inside the container.
+        read_only: When True, mount the volume read-only.
+        sub_path: Optional path within the volume to mount.
+    """
+
+    volume: str
+    mount_path: str
+    read_only: bool = False
+    sub_path: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.volume:
+            raise ValueError("VolumeMount.volume cannot be empty")
+        _validate_absolute_mount_path(self.mount_path, field="VolumeMount.mount_path")
+        if self.sub_path is not None and not self.sub_path:
+            object.__setattr__(self, "sub_path", None)
+
+
+def _coerce_volume_mount(value: VolumeMount | Mapping[str, Any]) -> VolumeMount:
+    if isinstance(value, VolumeMount):
+        return value
+    if isinstance(value, Mapping):
+        return VolumeMount(**value)
+    raise TypeError(
+        f"volume_mounts entries must be VolumeMount or dict, got {type(value).__name__}"
     )
 
 
@@ -1040,6 +1109,125 @@ class ResourceOptions:
             object.__setattr__(self, "gpu", None)
 
 
+@dataclass(frozen=True, kw_only=True)
+class Container:
+    """One user container in a sandbox.
+
+    Pass a list to ``Sandbox.run(containers=[...])``. That form is mutually
+    exclusive with the single-container kwargs (``container_image``,
+    ``command``/``args``, ``resources``, ``mounted_files``, ``secrets``,
+    ``image_pull_credentials``, ``environment_variables``).
+
+    One container: ``primary`` may be omitted or False (that row is primary).
+    More than one: exactly one row must set ``primary=True``, and every row
+    needs a name and resources. GPU is allowed only on the primary.
+
+    Attributes:
+        image: OCI image to run.
+        name: DNS-1123 label. Optional for a single container; required when
+            more than one container is specified.
+        command: Entrypoint. Empty/None uses the image entrypoint. Args may
+            be set without command.
+        args: Arguments to the command or image entrypoint.
+        environment_variables: Env vars injected into this container only.
+        resources: CPU/memory/GPU for this container. Required when more
+            than one container is specified.
+        mounted_files: Files written into this container at startup.
+        volume_mounts: Sandbox-level volumes to mount into this container.
+        secrets: Secret-store inject for this container only.
+        working_dir: Working directory for the command. Must be absolute
+            when set.
+        image_pull_credentials: Private-registry pull credentials.
+        primary: When True, this container owns sandbox lifecycle and is
+            the default exec/logs/files target.
+    """
+
+    image: str
+    name: str | None = None
+    command: str | None = None
+    args: Sequence[str] | None = None
+    environment_variables: Mapping[str, str] | None = None
+    resources: ResourceOptions | dict[str, Any] | None = None
+    mounted_files: Sequence[Mapping[str, Any]] | None = None
+    volume_mounts: Sequence[VolumeMount | Mapping[str, Any]] | None = None
+    secrets: Sequence[Secret | Mapping[str, Any]] | None = None
+    working_dir: str | None = None
+    image_pull_credentials: ImagePullCredentials | Mapping[str, Any] | None = None
+    primary: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.image:
+            raise ValueError("Container.image cannot be empty")
+        if self.name is not None:
+            if not self.name:
+                object.__setattr__(self, "name", None)
+            else:
+                _validate_container_name(self.name)
+        if self.command is not None and not self.command:
+            object.__setattr__(self, "command", None)
+        if self.args is not None:
+            object.__setattr__(self, "args", tuple(self.args))
+        if self.environment_variables is not None:
+            object.__setattr__(self, "environment_variables", dict(self.environment_variables))
+        if self.working_dir is not None:
+            if not self.working_dir:
+                object.__setattr__(self, "working_dir", None)
+            else:
+                _validate_absolute_mount_path(self.working_dir, field="Container.working_dir")
+        if self.volume_mounts is not None:
+            object.__setattr__(
+                self,
+                "volume_mounts",
+                tuple(_coerce_volume_mount(m) for m in self.volume_mounts),
+            )
+        if self.secrets is not None:
+            object.__setattr__(
+                self,
+                "secrets",
+                tuple(s if isinstance(s, Secret) else Secret(**s) for s in self.secrets),
+            )
+        if self.image_pull_credentials is not None and not isinstance(
+            self.image_pull_credentials, ImagePullCredentials
+        ):
+            object.__setattr__(
+                self,
+                "image_pull_credentials",
+                ImagePullCredentials(**self.image_pull_credentials),
+            )
+        if self.mounted_files is not None:
+            object.__setattr__(self, "mounted_files", tuple(self.mounted_files))
+
+
+def _coerce_container(value: Container | Mapping[str, Any]) -> Container:
+    if isinstance(value, Container):
+        return value
+    if isinstance(value, Mapping):
+        return Container(**value)
+    raise TypeError(f"containers entries must be Container or dict, got {type(value).__name__}")
+
+
+def _validate_containers(containers: Sequence[Container]) -> tuple[Container, ...]:
+    """Validate a create-time container list (names, primary flag)."""
+    if not containers:
+        raise ValueError("containers cannot be empty")
+    rows = tuple(containers)
+    if len(rows) > 1:
+        primary_count = sum(1 for row in rows if row.primary)
+        if primary_count != 1:
+            raise ValueError("containers with more than one entry require exactly one primary=True")
+        missing = [i for i, row in enumerate(rows) if not row.name]
+        if missing:
+            raise ValueError("every container must have a name when more than one is specified")
+    seen: set[str] = set()
+    for row in rows:
+        if not row.name:
+            continue
+        if row.name in seen:
+            raise ValueError(f"duplicate container name: {row.name!r}")
+        seen.add(row.name)
+    return rows
+
+
 class FileSystemSnapshotStatus(StrEnum):
     """Lifecycle status of a file-system snapshot (FSS).
 
@@ -1094,31 +1282,28 @@ class FileSystemSnapshotOptions:
     """Convenience single-mount wrapper over a named scratch volume.
 
     Prefer ``ScratchVolumeOptions`` / ``volumes=`` for multi-volume sandboxes.
-    This helper maps to a scratch volume named ``workspace`` (or ``name``)
-    mounted at ``mount_path``.
+    This helper maps to a scratch volume named ``workspace`` (or ``name``).
+    ``mount_path`` is optional: omit it to declare the volume without
+    mounting, and attach it via ``Container.volume_mounts``.
 
     Attributes:
-        mount_path: Absolute directory to mount (e.g. "/workspace").
+        mount_path: Absolute directory to mount (e.g. "/workspace"). None
+            declares the volume without a convenience mount.
         size: Mount size as a Kubernetes resource quantity (e.g. "10Gi").
         file_system_snapshot_id: When set, restore this snapshot at start.
         name: Scratch volume name (default ``"workspace"``).
     """
 
-    mount_path: str
+    mount_path: str | None = None
     size: str | None = None
     file_system_snapshot_id: str | None = None
     name: str = "workspace"
 
     def __post_init__(self) -> None:
-        if not self.mount_path:
-            raise ValueError("FileSystemSnapshotOptions.mount_path cannot be empty")
-        if not self.mount_path.startswith("/"):
-            raise ValueError(
-                f"FileSystemSnapshotOptions.mount_path must be an absolute path, "
-                f"got: {self.mount_path!r}"
+        if self.mount_path is not None:
+            _validate_absolute_mount_path(
+                self.mount_path, field="FileSystemSnapshotOptions.mount_path"
             )
-        if self.mount_path == "/":
-            raise ValueError("FileSystemSnapshotOptions.mount_path cannot be '/'")
         if not self.name:
             raise ValueError("FileSystemSnapshotOptions.name cannot be empty")
         if self.size is not None and not self.size:

--- a/src/cwsandbox/cli/exec.py
+++ b/src/cwsandbox/cli/exec.py
@@ -31,11 +31,17 @@ from cwsandbox import Sandbox
     default=None,
     help="Timeout in seconds.",
 )
+@click.option(
+    "--container",
+    default=None,
+    help="Container name. Omit to target the primary.",
+)
 def exec_command(
     sandbox_id: str,
     command: tuple[str, ...],
     cwd: str | None,
     timeout_seconds: float | None,
+    container: str | None,
 ) -> None:
     """Execute a command in a sandbox.
 
@@ -56,6 +62,7 @@ def exec_command(
             list(command),
             cwd=cwd,
             timeout_seconds=timeout_seconds,
+            container=container,
         )
 
         def _drain_stderr() -> None:

--- a/src/cwsandbox/cli/files.py
+++ b/src/cwsandbox/cli/files.py
@@ -37,8 +37,17 @@ def files() -> None:
     default=None,
     help="Timeout in seconds.",
 )
+@click.option(
+    "--container",
+    default=None,
+    help="Container name. Omit to target the primary.",
+)
 def read_file(
-    sandbox_id: str, remote_path: str, output_path: Path | None, timeout_seconds: float | None
+    sandbox_id: str,
+    remote_path: str,
+    output_path: Path | None,
+    timeout_seconds: float | None,
+    container: str | None,
 ) -> None:
     """Read a file from a sandbox.
 
@@ -46,7 +55,11 @@ def read_file(
     REMOTE_PATH is the file path inside the sandbox.
     """
     sandbox = Sandbox.from_id(sandbox_id).result()
-    data = sandbox.read_file(remote_path, timeout_seconds=timeout_seconds).result()
+    data = sandbox.read_file(
+        remote_path,
+        timeout_seconds=timeout_seconds,
+        container=container,
+    ).result()
 
     if output_path is not None:
         output_path.write_bytes(data)
@@ -74,12 +87,18 @@ def read_file(
     help="Timeout in seconds.",
 )
 @click.option("--quiet", "-q", is_flag=True, default=False, help="Suppress success output.")
+@click.option(
+    "--container",
+    default=None,
+    help="Container name. Omit to target the primary.",
+)
 def write_file(
     sandbox_id: str,
     remote_path: str,
     local_path: Path,
     timeout_seconds: float | None,
     quiet: bool,
+    container: str | None,
 ) -> None:
     """Write a local file into a sandbox.
 
@@ -89,7 +108,12 @@ def write_file(
     """
     data = local_path.read_bytes()
     sandbox = Sandbox.from_id(sandbox_id).result()
-    sandbox.write_file(remote_path, data, timeout_seconds=timeout_seconds).result()
+    sandbox.write_file(
+        remote_path,
+        data,
+        timeout_seconds=timeout_seconds,
+        container=container,
+    ).result()
 
     if not quiet:
         click.echo(f"Wrote {len(data)} bytes to {remote_path}.")

--- a/src/cwsandbox/cli/get.py
+++ b/src/cwsandbox/cli/get.py
@@ -16,7 +16,7 @@ from cwsandbox import Sandbox
 
 def _sandbox_details(sandbox: Sandbox) -> dict[str, Any]:
     """Return the CLI detail payload for a sandbox."""
-    return {
+    details: dict[str, Any] = {
         "sandbox_id": sandbox.sandbox_id,
         "status": sandbox.status.value if sandbox.status else None,
         "runner_id": sandbox.runner_id,
@@ -24,6 +24,28 @@ def _sandbox_details(sandbox: Sandbox) -> dict[str, Any]:
         "started_at": sandbox.started_at.isoformat() if sandbox.started_at else None,
         "returncode": sandbox.returncode,
     }
+    containers = getattr(sandbox, "containers", ())
+    if isinstance(containers, (list, tuple)) and containers:
+        details["containers"] = [
+            {
+                "name": row.name,
+                "image": row.image,
+                "primary": row.primary,
+            }
+            for row in containers
+        ]
+    statuses = getattr(sandbox, "container_statuses", ())
+    if isinstance(statuses, (list, tuple)) and statuses:
+        details["container_statuses"] = [
+            {
+                "name": row.name,
+                "state": row.state.value if hasattr(row.state, "value") else str(row.state),
+                "exit_code": row.exit_code,
+                "restart_count": row.restart_count,
+            }
+            for row in statuses
+        ]
+    return details
 
 
 def _display_value(value: Any) -> str:
@@ -66,3 +88,24 @@ def get_sandbox(sandbox_id: str, output_format: str) -> None:
     width = max(len(label) for label, _ in rows)
     for label, value in rows:
         click.echo(f"{label:<{width}}  {_display_value(value)}")
+
+    containers = details.get("containers") or ()
+    if containers:
+        click.echo("")
+        click.echo("CONTAINERS")
+        for row in containers:
+            marker = "primary" if row.get("primary") else "helper"
+            name = row.get("name") or "-"
+            image = row.get("image") or "-"
+            click.echo(f"  {name} ({marker})  {image}")
+
+    statuses = details.get("container_statuses") or ()
+    if statuses:
+        click.echo("")
+        click.echo("CONTAINER STATUS")
+        for row in statuses:
+            name = row.get("name") or "-"
+            state = row.get("state") or "-"
+            exit_code = row.get("exit_code")
+            restarts = row.get("restart_count")
+            click.echo(f"  {name}  {state}  exit={exit_code}  restarts={restarts}")

--- a/src/cwsandbox/cli/get.py
+++ b/src/cwsandbox/cli/get.py
@@ -108,4 +108,5 @@ def get_sandbox(sandbox_id: str, output_format: str) -> None:
             state = row.get("state") or "-"
             exit_code = row.get("exit_code")
             restarts = row.get("restart_count")
-            click.echo(f"  {name}  {state}  exit={exit_code}  restarts={restarts}")
+            extra = f"  exit={exit_code}" if exit_code is not None else ""
+            click.echo(f"  {name}  {state}{extra}  restarts={restarts}")

--- a/src/cwsandbox/cli/logs.py
+++ b/src/cwsandbox/cli/logs.py
@@ -33,12 +33,18 @@ from cwsandbox import Sandbox
     help="Show logs since timestamp (e.g. 'YYYY-MM-DD' or 'YYYY-MM-DD HH:MM:SS').",
 )
 @click.option("--timestamps", "-t", is_flag=True, default=False, help="Show timestamps.")
+@click.option(
+    "--container",
+    default=None,
+    help="Container name. Omit to target the primary.",
+)
 def logs(
     sandbox_id: str,
     follow: bool,
     tail_lines: int | None,
     since_time: datetime | None,
     timestamps: bool,
+    container: str | None,
 ) -> None:
     """Stream logs from a sandbox's main process.
 
@@ -61,6 +67,7 @@ def logs(
         tail_lines=tail_lines,
         since_time=since_time,
         timestamps=timestamps,
+        container=container,
     )
     try:
         for line in reader:

--- a/src/cwsandbox/cli/shell.py
+++ b/src/cwsandbox/cli/shell.py
@@ -43,7 +43,12 @@ def _validate_cmd(ctx: click.Context, param: click.Parameter, value: str) -> str
     callback=_validate_cmd,
     help="Command to run (default: /bin/bash). Accepts full command strings.",
 )
-def shell(sandbox_id: str, cmd: str) -> None:
+@click.option(
+    "--container",
+    default=None,
+    help="Container name. Omit to target the primary.",
+)
+def shell(sandbox_id: str, cmd: str, container: str | None) -> None:
     """Open an interactive shell in a sandbox.
 
     SANDBOX_ID is the ID of the sandbox to connect to.
@@ -82,6 +87,7 @@ def shell(sandbox_id: str, cmd: str) -> None:
         command,
         width=size.columns,
         height=size.lines,
+        container=container,
     )
 
     # Raw mode forwards all keystrokes (incl. Ctrl+C) to the remote session

--- a/tests/integration/cwsandbox/test_multi_container.py
+++ b/tests/integration/cwsandbox/test_multi_container.py
@@ -1,0 +1,233 @@
+# SPDX-FileCopyrightText: 2025 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: cwsandbox-client
+
+"""Integration tests for v1 multi-container sandboxes.
+
+These tests require a running CWSandbox backend that admits more than one
+user container. When the fleet rejects N>1 (not implemented, or a
+single-container limit), they skip rather than fail.
+
+Set CWSANDBOX_BASE_URL and CWSANDBOX_API_KEY before running.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from cwsandbox import (
+    Container,
+    Sandbox,
+    SandboxDefaults,
+    ScratchVolumeOptions,
+    VolumeMount,
+)
+from cwsandbox._sandbox import SandboxStatus
+from cwsandbox.exceptions import SandboxError, SandboxFileError, SnapshotNotSupportedError
+
+_IMAGE = "python:3.11"
+_REDIS_IMAGE = "redis:7"
+_RESOURCES: dict[str, str] = {"cpu": "500m", "memory": "256Mi"}
+_PRIMARY = "main"
+_HELPER = "helper"
+_CACHE = "cache"
+
+# RESP SET from the primary. One connection; a refused or timed-out connect
+# is a failed loopback, not a race to retry.
+_REDIS_SET = (
+    "import socket, sys\n"
+    "key, value = sys.argv[1], sys.argv[2]\n"
+    "def bulk(s: str) -> bytes:\n"
+    "    b = s.encode()\n"
+    "    return b'$%d\\r\\n' % len(b) + b + b'\\r\\n'\n"
+    "payload = b'*3\\r\\n$3\\r\\nSET\\r\\n' + bulk(key) + bulk(value)\n"
+    "with socket.create_connection(('127.0.0.1', 6379), timeout=3) as sock:\n"
+    "    sock.sendall(payload)\n"
+    "    print(sock.recv(64).decode(), end='')\n"
+)
+
+_SKIP_HINTS = (
+    "not implemented",
+    "unimplemented",
+    "at most 1 container",
+    "at most one container",
+    "only one container",
+    "single container",
+)
+
+
+def _skip_if_multi_container_unavailable(exc: BaseException) -> None:
+    """Skip when the backend does not admit more than one user container."""
+    reason = getattr(exc, "reason", None) or ""
+    text = str(exc).lower()
+    if "NOT_IMPLEMENTED" in reason or any(hint in text for hint in _SKIP_HINTS):
+        pytest.skip(f"backend does not admit multi-container: {exc}")
+
+
+def _keepalive(**overrides: object) -> Container:
+    kwargs: dict[str, object] = {
+        "image": _IMAGE,
+        "command": "sleep",
+        "args": ("infinity",),
+        "resources": _RESOURCES,
+    }
+    kwargs.update(overrides)
+    return Container(**kwargs)  # type: ignore[arg-type]
+
+
+def _pair(*, volume_mounts: list[VolumeMount] | None = None) -> list[Container]:
+    mounts = volume_mounts
+    return [
+        _keepalive(name=_PRIMARY, primary=True, volume_mounts=mounts),
+        _keepalive(name=_HELPER, volume_mounts=mounts),
+    ]
+
+
+@pytest.fixture
+def multi_container_defaults(sandbox_defaults: SandboxDefaults) -> SandboxDefaults:
+    """Longer lifetime: N>1 start plus two execs can exceed the 60s fixture."""
+    return sandbox_defaults.with_overrides(max_lifetime_seconds=300)
+
+
+def test_multi_container_exec_files_and_echo(
+    multi_container_defaults: SandboxDefaults,
+) -> None:
+    """N=2 create reaches RUNNING; default ops hit primary; container= isolates."""
+    try:
+        with Sandbox.run(
+            containers=_pair(),
+            defaults=multi_container_defaults,
+        ) as sandbox:
+            sandbox.wait()
+            assert sandbox.status == SandboxStatus.RUNNING
+
+            by_name = {row.name: row for row in sandbox.containers}
+            assert set(by_name) == {_PRIMARY, _HELPER}
+            assert by_name[_PRIMARY].primary is True
+            assert by_name[_HELPER].primary is False
+            assert by_name[_PRIMARY].image == _IMAGE
+            assert by_name[_HELPER].image == _IMAGE
+
+            status_by_name = {row.name: row for row in sandbox.container_statuses}
+            assert set(status_by_name) == {_PRIMARY, _HELPER}
+
+            primary_marker = uuid.uuid4().hex
+            primary = sandbox.exec(
+                ["sh", "-c", f"echo {primary_marker} > /tmp/primary.txt && cat /tmp/primary.txt"]
+            ).result()
+            assert primary.returncode == 0
+            assert primary_marker in primary.stdout
+
+            helper_marker = uuid.uuid4().hex
+            helper = sandbox.exec(
+                [
+                    "sh",
+                    "-c",
+                    f"echo {helper_marker} > /tmp/helper.txt && cat /tmp/helper.txt",
+                ],
+                container=_HELPER,
+            ).result()
+            assert helper.returncode == 0
+            assert helper_marker in helper.stdout
+
+            miss = sandbox.exec(["cat", "/tmp/helper.txt"]).result()
+            assert miss.returncode != 0
+
+            path = f"/tmp/file_{uuid.uuid4().hex}.txt"
+            payload = b"from-helper"
+            sandbox.write_file(path, payload, container=_HELPER).result()
+            assert sandbox.read_file(path, container=_HELPER).result() == payload
+            with pytest.raises(SandboxFileError):
+                sandbox.read_file(path).result()
+    except SandboxError as exc:
+        _skip_if_multi_container_unavailable(exc)
+        raise
+
+
+def test_multi_container_shared_volume(
+    multi_container_defaults: SandboxDefaults,
+) -> None:
+    """A declare-only scratch volume is visible to both containers when mounted."""
+    mount = VolumeMount(volume="workspace", mount_path="/shared")
+    try:
+        with Sandbox.run(
+            containers=_pair(volume_mounts=[mount]),
+            volumes=[ScratchVolumeOptions(name="workspace", size="1Gi")],
+            defaults=multi_container_defaults,
+        ) as sandbox:
+            sandbox.wait()
+            marker = uuid.uuid4().hex
+            write = sandbox.exec(["sh", "-c", f"echo {marker} > /shared/marker.txt"]).result()
+            assert write.returncode == 0
+            read = sandbox.exec(["cat", "/shared/marker.txt"], container=_HELPER).result()
+            assert read.returncode == 0
+            assert marker in read.stdout
+    except SnapshotNotSupportedError:
+        pytest.skip("Organization is not enabled for scratch / file-system snapshots")
+    except SandboxError as exc:
+        _skip_if_multi_container_unavailable(exc)
+        raise
+
+
+def test_multi_container_localhost_helper(
+    multi_container_defaults: SandboxDefaults,
+) -> None:
+    """Primary talks to a different-image helper on loopback.
+
+    RUNNING means the helper process has Started, not that it is listening.
+    Wait for redis-cli PING inside the cache container, then SET from the
+    primary exactly once. Retrying that SET would hide a missing shared
+    network namespace.
+    """
+    containers = [
+        _keepalive(name=_PRIMARY, primary=True),
+        Container(
+            image=_REDIS_IMAGE,
+            name=_CACHE,
+            resources=_RESOURCES,
+        ),
+    ]
+    try:
+        with Sandbox.run(
+            containers=containers,
+            defaults=multi_container_defaults,
+        ) as sandbox:
+            sandbox.wait()
+            assert sandbox.status == SandboxStatus.RUNNING
+
+            by_name = {row.name: row for row in sandbox.containers}
+            assert set(by_name) == {_PRIMARY, _CACHE}
+            assert by_name[_PRIMARY].primary is True
+            assert by_name[_CACHE].primary is False
+            assert by_name[_PRIMARY].image == _IMAGE
+            assert by_name[_CACHE].image == _REDIS_IMAGE
+
+            ready = sandbox.exec(
+                [
+                    "sh",
+                    "-c",
+                    'i=0; while [ "$i" -lt 40 ]; do '
+                    "redis-cli PING && exit 0; "
+                    "i=$((i+1)); sleep 0.25; "
+                    "done; echo 'redis never answered PING' >&2; exit 1",
+                ],
+                container=_CACHE,
+                timeout_seconds=20,
+            ).result()
+            assert ready.returncode == 0, ready.stderr or ready.stdout
+            assert ready.stdout.strip().splitlines()[-1] == "PONG"
+
+            key = uuid.uuid4().hex
+            value = uuid.uuid4().hex
+            written = sandbox.exec(["python", "-c", _REDIS_SET, key, value]).result()
+            assert written.returncode == 0, written.stderr or written.stdout
+            assert written.stdout.strip() == "+OK"
+
+            got = sandbox.exec(["redis-cli", "GET", key], container=_CACHE).result()
+            assert got.returncode == 0, got.stderr or got.stdout
+            assert got.stdout.strip() == value
+    except SandboxError as exc:
+        _skip_if_multi_container_unavailable(exc)
+        raise

--- a/tests/unit/cwsandbox/test_cli_exec.py
+++ b/tests/unit/cwsandbox/test_cli_exec.py
@@ -53,6 +53,7 @@ class TestExecCommand:
             ["echo", "hello"],
             cwd=None,
             timeout_seconds=None,
+            container=None,
         )
 
     def test_exec_nonzero_returncode(self) -> None:
@@ -79,6 +80,7 @@ class TestExecCommand:
             ["ls"],
             cwd="/app",
             timeout_seconds=None,
+            container=None,
         )
 
     def test_exec_with_timeout(self) -> None:
@@ -97,6 +99,26 @@ class TestExecCommand:
             ["sleep", "10"],
             cwd=None,
             timeout_seconds=30.0,
+            container=None,
+        )
+
+    def test_exec_with_container(self) -> None:
+        """cwsandbox exec --container passes container to sandbox.exec."""
+        process = make_process(command=["echo", "hi"])
+
+        with _patch_sandbox(process) as mock_cls:
+            mock_sandbox = mock_cls.from_id.return_value.result()
+            runner = CliRunner()
+            result = runner.invoke(
+                cli, ["exec", "test-sandbox-id", "--container", "cache", "echo", "hi"]
+            )
+
+        assert result.exit_code == 0
+        mock_sandbox.exec.assert_called_once_with(
+            ["echo", "hi"],
+            cwd=None,
+            timeout_seconds=None,
+            container="cache",
         )
 
     def test_exec_concurrent_stdout_stderr(self) -> None:

--- a/tests/unit/cwsandbox/test_cli_files.py
+++ b/tests/unit/cwsandbox/test_cli_files.py
@@ -49,6 +49,7 @@ class TestFilesCommand:
         mock_sandbox.read_file.assert_called_once_with(
             "/tmp/data.txt",
             timeout_seconds=None,
+            container=None,
         )
 
     def test_files_read_writes_output_file(self, tmp_path: Path) -> None:
@@ -82,6 +83,25 @@ class TestFilesCommand:
         mock_sandbox.read_file.assert_called_once_with(
             "/tmp/data.txt",
             timeout_seconds=5.0,
+            container=None,
+        )
+
+    def test_files_read_with_container(self) -> None:
+        """cwsandbox files read --container passes container to read_file."""
+        mock_sandbox = MagicMock()
+        mock_sandbox.read_file.return_value = make_operation_ref(b"ok")
+
+        with _patch_sandbox(mock_sandbox):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli, ["files", "read", "sb-1", "/tmp/data.txt", "--container", "cache"]
+            )
+
+        assert result.exit_code == 0
+        mock_sandbox.read_file.assert_called_once_with(
+            "/tmp/data.txt",
+            timeout_seconds=None,
+            container="cache",
         )
 
     def test_files_write_uploads_local_file(self, tmp_path: Path) -> None:
@@ -103,6 +123,7 @@ class TestFilesCommand:
             "/tmp/data.txt",
             b"hello\n",
             timeout_seconds=None,
+            container=None,
         )
 
     def test_files_write_with_options(self, tmp_path: Path) -> None:
@@ -134,6 +155,38 @@ class TestFilesCommand:
             "/tmp/data.txt",
             b"hello",
             timeout_seconds=7.0,
+            container=None,
+        )
+
+    def test_files_write_with_container(self, tmp_path: Path) -> None:
+        """cwsandbox files write --container passes container to write_file."""
+        local_path = tmp_path / "data.txt"
+        local_path.write_bytes(b"hello")
+        mock_sandbox = MagicMock()
+        mock_sandbox.write_file.return_value = make_operation_ref(None)
+
+        with _patch_sandbox(mock_sandbox):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                [
+                    "files",
+                    "write",
+                    "sb-1",
+                    "/tmp/data.txt",
+                    str(local_path),
+                    "--container",
+                    "cache",
+                    "--quiet",
+                ],
+            )
+
+        assert result.exit_code == 0
+        mock_sandbox.write_file.assert_called_once_with(
+            "/tmp/data.txt",
+            b"hello",
+            timeout_seconds=None,
+            container="cache",
         )
 
     def test_files_read_sandbox_not_found(self) -> None:

--- a/tests/unit/cwsandbox/test_cli_get.py
+++ b/tests/unit/cwsandbox/test_cli_get.py
@@ -82,6 +82,37 @@ class TestGetCommand:
         )
         assert result.output.strip() == expected
 
+    def test_get_displays_containers(self) -> None:
+        """cwsandbox get shows container spec and status when present."""
+        from types import SimpleNamespace
+
+        mock_sandbox = _mock_sandbox()
+        mock_sandbox.containers = (
+            SimpleNamespace(name="main", image="python:3.11", primary=True),
+            SimpleNamespace(name="cache", image="redis:7", primary=False),
+        )
+        mock_sandbox.container_statuses = (
+            SimpleNamespace(
+                name="main", state=SimpleNamespace(value="running"), exit_code=0, restart_count=0
+            ),
+            SimpleNamespace(
+                name="cache", state=SimpleNamespace(value="running"), exit_code=0, restart_count=1
+            ),
+        )
+
+        with patch("cwsandbox.cli.get.Sandbox") as mock_sandbox_cls:
+            mock_sandbox_cls.from_id.return_value = make_operation_ref(mock_sandbox)
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ["get", "abc-123"])
+
+        assert result.exit_code == 0
+        assert "CONTAINERS" in result.output
+        assert "main (primary)" in result.output
+        assert "cache (helper)" in result.output
+        assert "CONTAINER STATUS" in result.output
+        assert "restarts=1" in result.output
+
     def test_get_sandbox_not_found(self) -> None:
         """cwsandbox get shows clean error for SandboxNotFoundError."""
         mock_op_ref = MagicMock()

--- a/tests/unit/cwsandbox/test_cli_get.py
+++ b/tests/unit/cwsandbox/test_cli_get.py
@@ -93,10 +93,16 @@ class TestGetCommand:
         )
         mock_sandbox.container_statuses = (
             SimpleNamespace(
-                name="main", state=SimpleNamespace(value="running"), exit_code=0, restart_count=0
+                name="main",
+                state=SimpleNamespace(value="running"),
+                exit_code=None,
+                restart_count=0,
             ),
             SimpleNamespace(
-                name="cache", state=SimpleNamespace(value="running"), exit_code=0, restart_count=1
+                name="cache",
+                state=SimpleNamespace(value="running"),
+                exit_code=None,
+                restart_count=1,
             ),
         )
 
@@ -112,6 +118,31 @@ class TestGetCommand:
         assert "cache (helper)" in result.output
         assert "CONTAINER STATUS" in result.output
         assert "restarts=1" in result.output
+        assert "exit=" not in result.output
+
+    def test_get_displays_terminal_container_exit_code(self) -> None:
+        """Terminal container rows include exit=; running rows omit it."""
+        from types import SimpleNamespace
+
+        mock_sandbox = _mock_sandbox()
+        mock_sandbox.containers = (SimpleNamespace(name="main", image="python:3.11", primary=True),)
+        mock_sandbox.container_statuses = (
+            SimpleNamespace(
+                name="main",
+                state=SimpleNamespace(value="completed"),
+                exit_code=0,
+                restart_count=0,
+            ),
+        )
+
+        with patch("cwsandbox.cli.get.Sandbox") as mock_sandbox_cls:
+            mock_sandbox_cls.from_id.return_value = make_operation_ref(mock_sandbox)
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ["get", "abc-123"])
+
+        assert result.exit_code == 0
+        assert "exit=0" in result.output
 
     def test_get_sandbox_not_found(self) -> None:
         """cwsandbox get shows clean error for SandboxNotFoundError."""

--- a/tests/unit/cwsandbox/test_cli_logs.py
+++ b/tests/unit/cwsandbox/test_cli_logs.py
@@ -62,6 +62,25 @@ class TestLogsCommand:
             tail_lines=None,
             since_time=None,
             timestamps=False,
+            container=None,
+        )
+
+    def test_logs_with_container(self) -> None:
+        """cwsandbox logs --container passes container to stream_logs."""
+        mock_sandbox = MagicMock()
+        mock_sandbox.stream_logs.return_value = _MockStreamReader([])
+
+        with _patch_sandbox(mock_sandbox):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["logs", "test-sandbox-id", "--container", "cache"])
+
+        assert result.exit_code == 0
+        mock_sandbox.stream_logs.assert_called_once_with(
+            follow=False,
+            tail_lines=None,
+            since_time=None,
+            timestamps=False,
+            container="cache",
         )
 
     def test_logs_follow_flag(self) -> None:
@@ -79,6 +98,7 @@ class TestLogsCommand:
             tail_lines=None,
             since_time=None,
             timestamps=False,
+            container=None,
         )
 
     def test_logs_with_options(self) -> None:
@@ -96,6 +116,7 @@ class TestLogsCommand:
             tail_lines=50,
             since_time=None,
             timestamps=True,
+            container=None,
         )
 
     def test_logs_since_option(self) -> None:

--- a/tests/unit/cwsandbox/test_cli_shell.py
+++ b/tests/unit/cwsandbox/test_cli_shell.py
@@ -138,9 +138,25 @@ class TestShellCommand:
             ["/bin/bash"],
             width=80,
             height=24,
+            container=None,
         )
         # Verify terminal was restored
         env["tcsetattr"].assert_called_once()
+
+    def test_shell_with_container(self) -> None:
+        """cwsandbox sh --container passes container to shell()."""
+        mock_sandbox = MagicMock()
+        with _terminal_env(mock_sandbox):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["sh", "test-sandbox-id", "--container", "cache"])
+
+        assert result.exit_code == 0
+        mock_sandbox.shell.assert_called_once_with(
+            ["/bin/bash"],
+            width=80,
+            height=24,
+            container="cache",
+        )
 
     def test_shell_custom_cmd(self) -> None:
         """cwsandbox shell --cmd passes custom command to shell()."""
@@ -157,6 +173,7 @@ class TestShellCommand:
             ["python", "main.py"],
             width=120,
             height=40,
+            container=None,
         )
 
     def test_shell_empty_cmd_error(self) -> None:

--- a/tests/unit/cwsandbox/test_defaults.py
+++ b/tests/unit/cwsandbox/test_defaults.py
@@ -440,6 +440,23 @@ class TestSandboxDefaultsFromDict:
         with pytest.raises(TypeError, match="profile_names"):
             SandboxDefaults.from_dict({"profile_names": ["default"]})
 
+    def test_from_dict_coerces_containers_dicts(self) -> None:
+        from cwsandbox import Container
+
+        defaults = SandboxDefaults.from_dict(
+            {
+                "containers": [
+                    {"image": "python:3.11", "name": "main", "primary": True},
+                    {"image": "redis:7", "name": "cache"},
+                ]
+            }
+        )
+        assert defaults.containers is not None
+        assert len(defaults.containers) == 2
+        assert isinstance(defaults.containers[0], Container)
+        assert defaults.containers[0].name == "main"
+        assert defaults.containers[1].image == "redis:7"
+
     def test_from_dict_coerces_services_and_volumes_dicts(self) -> None:
         from cwsandbox._types import ScratchVolumeOptions, Service
 

--- a/tests/unit/cwsandbox/test_file_system_snapshot.py
+++ b/tests/unit/cwsandbox/test_file_system_snapshot.py
@@ -109,6 +109,14 @@ def _bare_rpc_error(code: grpc.StatusCode, details: str = "boom") -> grpc.RpcErr
 
 
 class TestFileSystemSnapshotOptions:
+    def test_mount_path_optional(self) -> None:
+        opts = FileSystemSnapshotOptions(size="10Gi")
+        assert opts.mount_path is None
+        scratch = opts.to_scratch_volume()
+        assert scratch.mount_path is None
+        assert scratch.name == "workspace"
+        assert scratch.size == "10Gi"
+
     def test_minimal(self) -> None:
         opts = FileSystemSnapshotOptions(mount_path="/workspace")
         assert opts.mount_path == "/workspace"

--- a/tests/unit/cwsandbox/test_function.py
+++ b/tests/unit/cwsandbox/test_function.py
@@ -600,6 +600,44 @@ class TestRemoteFunction:
             mock_sandbox.read_file.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_execute_async_clears_session_container_defaults(self) -> None:
+        """@session.function() ignores session containers= defaults."""
+        from cwsandbox import Container, ResourceOptions, SandboxDefaults, Session
+
+        cpu = ResourceOptions(requests={"cpu": "1"}, limits={"cpu": "1"})
+        defaults = SandboxDefaults(
+            containers=(
+                Container(image="redis:7", name="main", primary=True, resources=cpu),
+                Container(image="redis:7", name="cache", resources=cpu),
+            ),
+            container_image="python:3.11",
+        )
+        session = Session(defaults)
+
+        def add(x: int, y: int) -> int:
+            return x + y
+
+        remote_fn = RemoteFunction(add, session=session, container_image="python:3.12")
+
+        mock_sandbox = MagicMock()
+        mock_sandbox.__aenter__ = AsyncMock(return_value=mock_sandbox)
+        mock_sandbox.__aexit__ = AsyncMock(return_value=None)
+        mock_sandbox._start_async = AsyncMock(return_value=None)
+        mock_sandbox.sandbox_id = "test-sandbox-id"
+        mock_sandbox.write_file = MagicMock(return_value=make_operation_ref(None))
+        mock_sandbox.exec = MagicMock(return_value=make_process(returncode=0))
+        mock_sandbox.read_file = MagicMock(return_value=make_operation_ref(json.dumps(5).encode()))
+
+        with patch("cwsandbox._sandbox.Sandbox") as MockSandbox:
+            MockSandbox.return_value = mock_sandbox
+            result = await remote_fn._execute_async(2, 3)
+
+        assert result == 5
+        call_kwargs = MockSandbox.call_args[1]
+        assert call_kwargs["container_image"] == "python:3.12"
+        assert call_kwargs["defaults"].containers is None
+
+    @pytest.mark.asyncio
     async def test_execute_async_raises_on_failure(self) -> None:
         """Test _execute_async raises SandboxExecutionError on non-zero exit."""
         from cwsandbox import Session

--- a/tests/unit/cwsandbox/test_multi_container.py
+++ b/tests/unit/cwsandbox/test_multi_container.py
@@ -1,0 +1,440 @@
+# SPDX-FileCopyrightText: 2025 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: cwsandbox-client
+
+"""Unit tests for v1 multi-container create, targeting, and echo."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cwsandbox import (
+    Container,
+    ContainerStatus,
+    FileSystemSnapshotOptions,
+    ResourceOptions,
+    Sandbox,
+    ScratchVolumeOptions,
+    VolumeMount,
+)
+from cwsandbox._proto import sandbox_pb2
+from cwsandbox._sandbox import SandboxStatus, _Running, _SandboxView, _Terminal
+from tests.unit.cwsandbox.test_sandbox import (
+    MockStreamCall,
+    create_mock_channel_and_stub,
+)
+
+
+def _cpu(cpu: str = "1") -> ResourceOptions:
+    return ResourceOptions(requests={"cpu": cpu}, limits={"cpu": cpu})
+
+
+def _run(*args: str, **kwargs: Any) -> tuple[Sandbox, MagicMock]:
+    from tests.unit.cwsandbox.test_sandbox import TestSandboxRun
+
+    sandbox, stub = TestSandboxRun._run_with_mock_stub(*args, **kwargs)
+    sandbox._state = _Terminal(sandbox_id="matrix-id", status=SandboxStatus.COMPLETED)
+    return sandbox, stub
+
+
+def _running_sandbox() -> Sandbox:
+    sandbox = Sandbox(command="sleep", args=["infinity"])
+    sandbox._sandbox_id = "sb-mc"
+    sandbox._state = _Running(sandbox_id="sb-mc")
+    sandbox._channel = MagicMock()
+    sandbox._stub = MagicMock()
+    sandbox._auth_metadata = ()
+    return sandbox
+
+
+class TestVolumeMount:
+    def test_valid(self) -> None:
+        mount = VolumeMount(volume="workspace", mount_path="/data", read_only=True, sub_path="x")
+        assert mount.volume == "workspace"
+        assert mount.mount_path == "/data"
+        assert mount.read_only is True
+        assert mount.sub_path == "x"
+
+    def test_empty_volume_raises(self) -> None:
+        with pytest.raises(ValueError, match="VolumeMount.volume"):
+            VolumeMount(volume="", mount_path="/data")
+
+    @pytest.mark.parametrize("path", ["", "relative", "/"])
+    def test_invalid_mount_path_raises(self, path: str) -> None:
+        with pytest.raises(ValueError, match="VolumeMount.mount_path"):
+            VolumeMount(volume="workspace", mount_path=path)
+
+    def test_empty_sub_path_normalized(self) -> None:
+        assert VolumeMount(volume="workspace", mount_path="/data", sub_path="").sub_path is None
+
+
+class TestContainerValidation:
+    def test_empty_image_raises(self) -> None:
+        with pytest.raises(ValueError, match="Container.image"):
+            Container(image="")
+
+    def test_empty_name_normalized(self) -> None:
+        assert Container(image="python:3.11", name="").name is None
+
+    def test_working_dir_must_be_absolute(self) -> None:
+        with pytest.raises(ValueError, match="Container.working_dir"):
+            Container(image="python:3.11", working_dir="app")
+
+    def test_reserved_name_raises(self) -> None:
+        with pytest.raises(ValueError, match="reserved"):
+            Container(image="python:3.11", name="dns-egress")
+
+    def test_reserved_prefix_raises(self) -> None:
+        with pytest.raises(ValueError, match="reserved"):
+            Container(image="python:3.11", name="cw-object-store-agent-restore-1")
+
+    def test_dns1123_rejects_uppercase_and_dots(self) -> None:
+        with pytest.raises(ValueError, match="DNS-1123 label"):
+            Container(image="python:3.11", name="Main")
+        with pytest.raises(ValueError, match="DNS-1123 label"):
+            Container(image="python:3.11", name="helper.one")
+
+    def test_dict_coercion_and_volume_mounts(self) -> None:
+        row = Container(
+            image="python:3.11",
+            volume_mounts=[{"volume": "workspace", "mount_path": "/workspace"}],
+        )
+        assert row.volume_mounts == (VolumeMount(volume="workspace", mount_path="/workspace"),)
+
+    def test_empty_list_raises(self) -> None:
+        with pytest.raises(ValueError, match="containers cannot be empty"):
+            Sandbox(containers=[])
+
+    def test_n_gt_1_requires_exactly_one_primary(self) -> None:
+        rows = [
+            Container(image="python:3.11", name="main", resources=_cpu()),
+            Container(image="redis:7", name="cache", resources=_cpu()),
+        ]
+        with pytest.raises(ValueError, match="exactly one primary=True"):
+            Sandbox(containers=rows)
+
+    def test_n_gt_1_requires_names(self) -> None:
+        with pytest.raises(ValueError, match="every container must have a name"):
+            Sandbox(
+                containers=[
+                    Container(image="python:3.11", primary=True, resources=_cpu()),
+                    Container(image="redis:7", name="cache", resources=_cpu()),
+                ]
+            )
+
+    def test_duplicate_names_raise(self) -> None:
+        with pytest.raises(ValueError, match="duplicate container name"):
+            Sandbox(
+                containers=[
+                    Container(image="python:3.11", name="main", primary=True, resources=_cpu()),
+                    Container(image="redis:7", name="main", resources=_cpu()),
+                ]
+            )
+
+    def test_n_gt_1_requires_resources(self) -> None:
+        with pytest.raises(ValueError, match="requires resources"):
+            Sandbox(
+                containers=[
+                    Container(image="python:3.11", name="main", primary=True, resources=_cpu()),
+                    Container(image="redis:7", name="cache"),
+                ]
+            )
+
+    def test_gpu_only_on_primary(self) -> None:
+        with pytest.raises(ValueError, match="GPU is only allowed on the primary"):
+            Sandbox(
+                containers=[
+                    Container(image="python:3.11", name="main", primary=True, resources=_cpu()),
+                    Container(
+                        image="redis:7",
+                        name="cache",
+                        resources=ResourceOptions(gpu={"count": 1}),
+                    ),
+                ]
+            )
+
+    def test_exclusive_with_single_container_kwargs(self) -> None:
+        with pytest.raises(TypeError, match="mutually exclusive"):
+            Sandbox(
+                containers=[Container(image="python:3.11")],
+                container_image="python:3.12",
+            )
+
+
+class TestCreateRequest:
+    def test_kwargs_path_names_main_and_omits_primary(self) -> None:
+        _, stub = _run("sleep", "infinity")
+        container = stub.CreateSandbox.call_args.args[0].sandbox.spec.containers[0]
+        assert container.name == "main"
+        assert not container.HasField("primary")
+        spec = stub.CreateSandbox.call_args.args[0].sandbox.spec
+        assert [fd.name for fd, _ in spec.ListFields() if fd.name == "primary_container"] == []
+
+    def test_single_container_omits_name_and_primary(self) -> None:
+        _, stub = _run(containers=[Container(image="python:3.11", working_dir="/app")])
+        container = stub.CreateSandbox.call_args.args[0].sandbox.spec.containers[0]
+        assert container.image == "python:3.11"
+        assert container.name == ""
+        assert container.working_dir == "/app"
+        assert not container.HasField("primary")
+
+    def test_multi_container_sets_primary_and_per_container_fields(self) -> None:
+        _, stub = _run(
+            containers=[
+                Container(
+                    image="python:3.11",
+                    name="main",
+                    primary=True,
+                    resources=_cpu("2"),
+                    volume_mounts=[VolumeMount(volume="workspace", mount_path="/workspace")],
+                    environment_variables={"ROLE": "primary"},
+                ),
+                Container(
+                    image="redis:7",
+                    name="cache",
+                    command="redis-server",
+                    args=["--save", ""],
+                    resources=_cpu("1"),
+                ),
+            ],
+            volumes=[ScratchVolumeOptions(name="workspace")],
+        )
+        spec = stub.CreateSandbox.call_args.args[0].sandbox.spec
+        assert [row.name for row in spec.containers] == ["main", "cache"]
+        assert spec.containers[0].primary is True
+        assert spec.containers[0].HasField("primary")
+        assert not spec.containers[1].HasField("primary")
+        assert spec.containers[0].resource_requirements.requests.cpu == "2"
+        assert spec.containers[1].command == "redis-server"
+        assert list(spec.containers[1].args) == ["--save", ""]
+        assert spec.containers[0].environment_variables["ROLE"] == "primary"
+        mounts = [(m.volume, m.mount_path) for m in spec.containers[0].volume_mounts]
+        assert mounts == [("workspace", "/workspace")]
+        assert list(spec.containers[1].volume_mounts) == []
+        assert spec.volumes[0].name == "workspace"
+        assert [fd.name for fd, _ in spec.ListFields() if fd.name == "primary_container"] == []
+
+    def test_declare_only_volume_does_not_mount(self) -> None:
+        _, stub = _run(volumes=[ScratchVolumeOptions(name="cache")])
+        spec = stub.CreateSandbox.call_args.args[0].sandbox.spec
+        assert spec.volumes[0].name == "cache"
+        assert list(spec.containers[0].volume_mounts) == []
+
+    def test_convenience_mount_attaches_to_primary(self) -> None:
+        _, stub = _run(
+            containers=[
+                Container(image="python:3.11", name="main", primary=True, resources=_cpu()),
+                Container(image="redis:7", name="cache", resources=_cpu()),
+            ],
+            volumes=[ScratchVolumeOptions(name="workspace", mount_path="/workspace")],
+        )
+        spec = stub.CreateSandbox.call_args.args[0].sandbox.spec
+        primary_mounts = [(m.volume, m.mount_path) for m in spec.containers[0].volume_mounts]
+        helper_mounts = list(spec.containers[1].volume_mounts)
+        assert primary_mounts == [("workspace", "/workspace")]
+        assert helper_mounts == []
+
+    def test_kwargs_path_convenience_mount(self) -> None:
+        _, stub = _run(volumes=[ScratchVolumeOptions(name="cache", mount_path="/cache")])
+        mount = stub.CreateSandbox.call_args.args[0].sandbox.spec.containers[0].volume_mounts[0]
+        assert mount.volume == "cache"
+        assert mount.mount_path == "/cache"
+
+    def test_fss_without_mount_path_declares_volume_only(self) -> None:
+        _, stub = _run(file_system_snapshot=FileSystemSnapshotOptions(size="10Gi"))
+        spec = stub.CreateSandbox.call_args.args[0].sandbox.spec
+        assert spec.volumes[0].name == "workspace"
+        assert spec.volumes[0].scratch.size == "10Gi"
+        assert list(spec.containers[0].volume_mounts) == []
+
+    def test_template_containers_replace_without_container_image(self) -> None:
+        from tests.unit.cwsandbox.test_sandbox import TestSandboxRun
+
+        sandbox, stub = TestSandboxRun._run_with_mock_stub(
+            template_id="template-123",
+            containers=[
+                Container(image="python:3.11", name="main", primary=True, resources=_cpu()),
+                Container(image="redis:7", name="cache", resources=_cpu()),
+            ],
+        )
+        sandbox._state = _Terminal(sandbox_id="template-id", status=SandboxStatus.COMPLETED)
+        request = stub.CreateSandboxFromTemplate.call_args.args[0]
+        assert [row.name for row in request.overrides.containers] == ["main", "cache"]
+        assert request.overrides.containers[0].primary is True
+        assert request.overrides.containers[0].image == "python:3.11"
+
+
+class TestContainerTarget:
+    def test_exec_sets_container_when_passed(self) -> None:
+        sandbox = _running_sandbox()
+        exit_response = sandbox_pb2.ExecStreamResponse(exit=sandbox_pb2.ExecStreamExit(exit_code=0))
+        mock_call = MockStreamCall(responses=[exit_response])
+        mock_channel, mock_stub = create_mock_channel_and_stub(mock_call)
+
+        with (
+            patch.object(sandbox, "_wait_until_running_async", new_callable=AsyncMock),
+            patch("cwsandbox._sandbox.resolve_auth_metadata", return_value=()),
+            patch("cwsandbox._sandbox.parse_grpc_target", return_value=("localhost:443", True)),
+            patch("cwsandbox._sandbox.create_channel", return_value=mock_channel),
+            patch(
+                "cwsandbox._sandbox.sandbox_pb2_grpc.SandboxServiceStub",
+                return_value=mock_stub,
+            ),
+        ):
+            sandbox.exec(["echo", "hi"], container="cache").result()
+
+        init = mock_call._writes[0].init
+        assert init.container == "cache"
+
+    def test_exec_omits_container_when_empty(self) -> None:
+        sandbox = _running_sandbox()
+        exit_response = sandbox_pb2.ExecStreamResponse(exit=sandbox_pb2.ExecStreamExit(exit_code=0))
+        mock_call = MockStreamCall(responses=[exit_response])
+        mock_channel, mock_stub = create_mock_channel_and_stub(mock_call)
+
+        with (
+            patch.object(sandbox, "_wait_until_running_async", new_callable=AsyncMock),
+            patch("cwsandbox._sandbox.resolve_auth_metadata", return_value=()),
+            patch("cwsandbox._sandbox.parse_grpc_target", return_value=("localhost:443", True)),
+            patch("cwsandbox._sandbox.create_channel", return_value=mock_channel),
+            patch(
+                "cwsandbox._sandbox.sandbox_pb2_grpc.SandboxServiceStub",
+                return_value=mock_stub,
+            ),
+        ):
+            sandbox.exec(["echo", "hi"]).result()
+
+        init = mock_call._writes[0].init
+        assert init.container == ""
+
+    def test_read_file_sets_container(self) -> None:
+        sandbox = _running_sandbox()
+        mock_read_response = MagicMock()
+        mock_read_response.content = b"ok"
+        sandbox._stub.ReadFile = AsyncMock(return_value=mock_read_response)
+
+        with (
+            patch.object(sandbox, "_ensure_client", new_callable=AsyncMock),
+            patch.object(sandbox, "_read_file_via_exec_streaming", new_callable=AsyncMock),
+        ):
+            data = sandbox.read_file("/tmp/x", container="cache").result()
+
+        assert data == b"ok"
+        request = sandbox._stub.ReadFile.await_args.args[0]
+        assert request.container == "cache"
+
+    def test_read_file_omits_container_when_unset(self) -> None:
+        sandbox = _running_sandbox()
+        mock_read_response = MagicMock()
+        mock_read_response.content = b"ok"
+        sandbox._stub.ReadFile = AsyncMock(return_value=mock_read_response)
+
+        with (
+            patch.object(sandbox, "_ensure_client", new_callable=AsyncMock),
+            patch.object(sandbox, "_read_file_via_exec_streaming", new_callable=AsyncMock),
+        ):
+            sandbox.read_file("/tmp/x").result()
+
+        request = sandbox._stub.ReadFile.await_args.args[0]
+        assert request.container == ""
+
+    @pytest.mark.asyncio
+    async def test_stream_logs_sets_container(self) -> None:
+        sandbox = _running_sandbox()
+        entries = [sandbox_pb2.LogEntry(data=b"line\n", log_session_id="s1", next_log_offset=1)]
+
+        class _Call:
+            def __init__(self, items: list[Any]) -> None:
+                self._items = items
+
+            def __aiter__(self) -> _Call:
+                return self
+
+            async def __anext__(self) -> Any:
+                if not self._items:
+                    raise StopAsyncIteration
+                return self._items.pop(0)
+
+        mock_channel = MagicMock()
+        mock_channel.close = AsyncMock()
+        mock_stub = MagicMock()
+        mock_stub.StreamLogs = MagicMock(return_value=_Call(list(entries)))
+        output_queue: asyncio.Queue[str | Exception | None] = asyncio.Queue()
+
+        with (
+            patch.object(sandbox, "_ensure_client", new_callable=AsyncMock),
+            patch.object(sandbox, "_wait_until_running_async", new_callable=AsyncMock),
+            patch.object(
+                sandbox,
+                "_get_or_create_streaming_channel",
+                new_callable=AsyncMock,
+                return_value=mock_channel,
+            ),
+            patch("cwsandbox._sandbox.sandbox_pb2_grpc.SandboxServiceStub", return_value=mock_stub),
+        ):
+            await sandbox._stream_logs_async(output_queue, follow=False, container="cache")
+
+        req = mock_stub.StreamLogs.call_args[0][0]
+        assert req.container == "cache"
+
+
+class TestStatusEcho:
+    def test_infers_primary_and_maps_container_statuses(self) -> None:
+        proto = sandbox_pb2.Sandbox(
+            sandbox_id="sb-1",
+            spec=sandbox_pb2.SandboxSpec(
+                containers=[
+                    sandbox_pb2.Container(name="main", image="python:3.11"),
+                    sandbox_pb2.Container(name="cache", image="redis:7"),
+                ]
+            ),
+            status=sandbox_pb2.SandboxStatus(
+                state=sandbox_pb2.STATE_RUNNING,
+                container_statuses=[
+                    sandbox_pb2.ContainerStatus(name="main", state=sandbox_pb2.STATE_RUNNING),
+                    sandbox_pb2.ContainerStatus(
+                        name="cache",
+                        state=sandbox_pb2.STATE_RUNNING,
+                        restart_count=2,
+                    ),
+                ],
+            ),
+        )
+        sandbox = Sandbox._from_sandbox_info(
+            _SandboxView(proto),
+            base_url="https://api.cwsandbox.com",
+            timeout_seconds=30.0,
+        )
+        assert [row.name for row in sandbox.containers] == ["main", "cache"]
+        assert sandbox.containers[0].primary is True
+        assert sandbox.containers[1].primary is False
+        assert sandbox.containers[0].image == "python:3.11"
+        assert [row.name for row in sandbox.container_statuses] == ["main", "cache"]
+        assert sandbox.container_statuses[1].restart_count == 2
+        assert sandbox.container_statuses[1].state == SandboxStatus.RUNNING
+        assert isinstance(sandbox.container_statuses[0], ContainerStatus)
+        sandbox._state = _Terminal(sandbox_id="sb-1", status=SandboxStatus.COMPLETED)
+
+    def test_preserves_explicit_primary_on_helper(self) -> None:
+        proto = sandbox_pb2.Sandbox(
+            sandbox_id="sb-1",
+            spec=sandbox_pb2.SandboxSpec(
+                containers=[
+                    sandbox_pb2.Container(name="sidecars", image="busybox"),
+                    sandbox_pb2.Container(name="main", image="python:3.11", primary=True),
+                ]
+            ),
+            status=sandbox_pb2.SandboxStatus(state=sandbox_pb2.STATE_RUNNING),
+        )
+        sandbox = Sandbox._from_sandbox_info(
+            _SandboxView(proto),
+            base_url="https://api.cwsandbox.com",
+            timeout_seconds=30.0,
+        )
+        assert sandbox.containers[0].primary is False
+        assert sandbox.containers[1].primary is True
+        sandbox._state = _Terminal(sandbox_id="sb-1", status=SandboxStatus.COMPLETED)

--- a/tests/unit/cwsandbox/test_multi_container.py
+++ b/tests/unit/cwsandbox/test_multi_container.py
@@ -18,7 +18,9 @@ from cwsandbox import (
     FileSystemSnapshotOptions,
     ResourceOptions,
     Sandbox,
+    SandboxDefaults,
     ScratchVolumeOptions,
+    Secret,
     VolumeMount,
 )
 from cwsandbox._proto import sandbox_pb2
@@ -105,6 +107,60 @@ class TestContainerValidation:
         )
         assert row.volume_mounts == (VolumeMount(volume="workspace", mount_path="/workspace"),)
 
+    def test_string_args_are_rejected(self) -> None:
+        with pytest.raises(TypeError, match="Container.args"):
+            Container(image="busybox", args="--save")  # type: ignore[arg-type]
+
+    def test_bytes_args_are_rejected(self) -> None:
+        with pytest.raises(TypeError, match="Container.args"):
+            Container(image="busybox", args=b"--save")  # type: ignore[arg-type]
+
+    def test_non_string_args_entries_are_rejected(self) -> None:
+        with pytest.raises(TypeError, match="Container.args\\[1\\]"):
+            Container(image="busybox", args=["--save", 1])  # type: ignore[list-item]
+
+    def test_from_dict_string_args_are_rejected(self) -> None:
+        with pytest.raises(TypeError, match="Container.args"):
+            SandboxDefaults.from_dict({"containers": [{"image": "busybox", "args": "--save"}]})
+
+    def test_conflicting_secrets_on_one_container_raise(self) -> None:
+        with pytest.raises(ValueError, match="Conflicting secrets for env_var 'TOKEN'"):
+            Container(
+                image="python:3.11",
+                secrets=[
+                    Secret(store="wandb", name="a", env_var="TOKEN"),
+                    Secret(store="vault", name="b", env_var="TOKEN"),
+                ],
+            )
+
+    def test_identical_secrets_on_one_container_dedupe(self) -> None:
+        secret = Secret(store="wandb", name="HF_TOKEN")
+        row = Container(image="python:3.11", secrets=[secret, secret])
+        assert row.secrets == (secret,)
+
+    def test_same_env_var_on_different_containers_is_allowed(self) -> None:
+        secret = Secret(store="wandb", name="HF_TOKEN", env_var="TOKEN")
+        sandbox = Sandbox(
+            containers=[
+                Container(
+                    image="python:3.11",
+                    name="main",
+                    primary=True,
+                    resources=_cpu(),
+                    secrets=[secret],
+                ),
+                Container(
+                    image="redis:7",
+                    name="cache",
+                    resources=_cpu(),
+                    secrets=[secret],
+                ),
+            ]
+        )
+        rows = sandbox._start_kwargs["containers"]
+        assert rows[0].secrets == (secret,)
+        assert rows[1].secrets == (secret,)
+
     def test_empty_list_raises(self) -> None:
         with pytest.raises(ValueError, match="containers cannot be empty"):
             Sandbox(containers=[])
@@ -163,6 +219,16 @@ class TestContainerValidation:
                 containers=[Container(image="python:3.11")],
                 container_image="python:3.12",
             )
+
+    def test_defaults_containers_conflict_with_container_image(self) -> None:
+        defaults = SandboxDefaults(
+            containers=[
+                Container(image="python:3.11", name="main", primary=True, resources=_cpu()),
+                Container(image="redis:7", name="cache", resources=_cpu()),
+            ]
+        )
+        with pytest.raises(TypeError, match="mutually exclusive"):
+            Sandbox(container_image="python:3.11", defaults=defaults)
 
 
 class TestCreateRequest:
@@ -416,7 +482,47 @@ class TestStatusEcho:
         assert [row.name for row in sandbox.container_statuses] == ["main", "cache"]
         assert sandbox.container_statuses[1].restart_count == 2
         assert sandbox.container_statuses[1].state == SandboxStatus.RUNNING
+        assert sandbox.container_statuses[0].exit_code is None
+        assert sandbox.container_statuses[1].exit_code is None
         assert isinstance(sandbox.container_statuses[0], ContainerStatus)
+        sandbox._state = _Terminal(sandbox_id="sb-1", status=SandboxStatus.COMPLETED)
+
+    def test_exit_code_only_for_terminal_container_status(self) -> None:
+        proto = sandbox_pb2.Sandbox(
+            sandbox_id="sb-1",
+            spec=sandbox_pb2.SandboxSpec(
+                containers=[sandbox_pb2.Container(name="main", image="python:3.11", primary=True)]
+            ),
+            status=sandbox_pb2.SandboxStatus(
+                state=sandbox_pb2.STATE_RUNNING,
+                container_statuses=[
+                    sandbox_pb2.ContainerStatus(
+                        name="main",
+                        state=sandbox_pb2.STATE_COMPLETED,
+                        exit_code=0,
+                    ),
+                    sandbox_pb2.ContainerStatus(
+                        name="cache",
+                        state=sandbox_pb2.STATE_FAILED,
+                        exit_code=1,
+                    ),
+                    sandbox_pb2.ContainerStatus(
+                        name="helper",
+                        state=sandbox_pb2.STATE_RUNNING,
+                        exit_code=0,
+                    ),
+                ],
+            ),
+        )
+        sandbox = Sandbox._from_sandbox_info(
+            _SandboxView(proto),
+            base_url="https://api.cwsandbox.com",
+            timeout_seconds=30.0,
+        )
+        by_name = {row.name: row for row in sandbox.container_statuses}
+        assert by_name["main"].exit_code == 0
+        assert by_name["cache"].exit_code == 1
+        assert by_name["helper"].exit_code is None
         sandbox._state = _Terminal(sandbox_id="sb-1", status=SandboxStatus.COMPLETED)
 
     def test_preserves_explicit_primary_on_helper(self) -> None:

--- a/tests/unit/cwsandbox/test_multi_container.py
+++ b/tests/unit/cwsandbox/test_multi_container.py
@@ -525,6 +525,32 @@ class TestStatusEcho:
         assert by_name["helper"].exit_code is None
         sandbox._state = _Terminal(sandbox_id="sb-1", status=SandboxStatus.COMPLETED)
 
+    def test_echo_keeps_platform_names_and_root_working_dir(self) -> None:
+        proto = sandbox_pb2.Sandbox(
+            sandbox_id="sb-1",
+            spec=sandbox_pb2.SandboxSpec(
+                containers=[
+                    sandbox_pb2.Container(
+                        name="dns-egress",
+                        image="platform/dns-egress:1",
+                        working_dir="/",
+                    ),
+                    sandbox_pb2.Container(name="Main", image="python:3.11"),
+                ]
+            ),
+            status=sandbox_pb2.SandboxStatus(state=sandbox_pb2.STATE_RUNNING),
+        )
+        sandbox = Sandbox._from_sandbox_info(
+            _SandboxView(proto),
+            base_url="https://api.cwsandbox.com",
+            timeout_seconds=30.0,
+        )
+        assert [row.name for row in sandbox.containers] == ["dns-egress", "Main"]
+        assert sandbox.containers[0].working_dir == "/"
+        assert sandbox.containers[0].primary is True
+        assert sandbox.containers[1].primary is False
+        sandbox._state = _Terminal(sandbox_id="sb-1", status=SandboxStatus.COMPLETED)
+
     def test_preserves_explicit_primary_on_helper(self) -> None:
         proto = sandbox_pb2.Sandbox(
             sandbox_id="sb-1",

--- a/tests/unit/cwsandbox/test_sandbox.py
+++ b/tests/unit/cwsandbox/test_sandbox.py
@@ -347,6 +347,7 @@ class TestSandboxRun:
     """Tests for Sandbox.run factory method."""
 
     @staticmethod
+    @staticmethod
     def _run_with_mock_stub(*args: str, **kwargs: Any) -> tuple[Sandbox, MagicMock]:
         mock_stub = MagicMock()
         mock_stub.CreateSandbox = AsyncMock(return_value=_create_sandbox_response("matrix-id"))

--- a/tests/unit/cwsandbox/test_sandbox.py
+++ b/tests/unit/cwsandbox/test_sandbox.py
@@ -878,14 +878,31 @@ class TestSandboxRun:
         with pytest.raises(TypeError, match="require container_image"):
             Sandbox.run_from_template("template-123", "-c", "echo ready")
 
-    def test_run_from_template_args_without_command_raises(self) -> None:
-        with pytest.raises(TypeError, match="args require command"):
-            Sandbox.run_from_template(
+    def test_run_from_template_args_without_command_are_honored(self) -> None:
+        stub = MagicMock()
+        stub.CreateSandbox = AsyncMock(return_value=_create_sandbox_response())
+        stub.CreateSandboxFromTemplate = AsyncMock(
+            return_value=_create_sandbox_response("template-id")
+        )
+
+        async def ensure_client(sandbox: Sandbox) -> None:
+            sandbox._channel = MagicMock()
+            sandbox._channel.close = AsyncMock()
+            sandbox._stub = stub
+
+        with patch.object(Sandbox, "_ensure_client", ensure_client):
+            sandbox = Sandbox.run_from_template(
                 "template-123",
                 "-c",
                 "echo ready",
                 container_image="python:3.11",
             )
+
+        request = stub.CreateSandboxFromTemplate.call_args.args[0]
+        assert request.overrides.containers[0].image == "python:3.11"
+        assert not request.overrides.containers[0].command
+        assert list(request.overrides.containers[0].args) == ["-c", "echo ready"]
+        sandbox._state = _Terminal(sandbox_id="template-id", status=SandboxStatus.COMPLETED)
 
     def test_run_from_template_command_without_image_raises(self) -> None:
         with pytest.raises(TypeError, match="require container_image"):
@@ -2492,6 +2509,7 @@ class TestSandboxFileTooLarge:
             timeout_seconds: float | None = None,
             operation: str,
             filepath: str | None = None,
+            container: str | None = None,
         ) -> tuple[int, bytes, bytes]:
             if hasattr(stdin, "__aiter__"):
                 async for chunk in stdin:  # type: ignore[union-attr]
@@ -2527,6 +2545,7 @@ class TestSandboxFileTooLarge:
             timeout_seconds: float | None = None,
             operation: str,
             filepath: str | None = None,
+            container: str | None = None,
         ) -> tuple[int, bytes, bytes]:
             raise SandboxStreamBackpressureError(
                 "output stream ended early; not read fast enough",
@@ -2571,6 +2590,7 @@ class TestSandboxFileTooLarge:
             timeout_seconds: float | None = None,
             operation: str,
             filepath: str | None = None,
+            container: str | None = None,
         ) -> tuple[int, bytes, bytes]:
             if hasattr(stdin, "__aiter__"):
                 async for _chunk in stdin:  # type: ignore[union-attr]
@@ -2677,6 +2697,7 @@ class TestSandboxFileTooLarge:
             timeout_seconds: float | None = None,
             operation: str,
             filepath: str | None = None,
+            container: str | None = None,
         ) -> tuple[int, bytes, bytes]:
             if hasattr(stdin, "__aiter__"):
                 async for chunk in stdin:  # type: ignore[union-attr]
@@ -2819,6 +2840,7 @@ class TestSandboxFileTooLarge:
             timeout_seconds: float | None = None,
             operation: str,
             filepath: str | None = None,
+            container: str | None = None,
         ) -> tuple[int, bytes, bytes]:
             async for chunk in stdin:  # type: ignore[union-attr]
                 seen_chunks.append(bytes(chunk))
@@ -3227,7 +3249,9 @@ class TestSandboxReadFileStreaming:
         sandbox = self._setup_running_sandbox()
         captured: dict[str, float] = {}
 
-        async def fake_stat(filepath: str, timeout: float) -> int | None:
+        async def fake_stat(
+            filepath: str, timeout: float, *, container: str | None = None
+        ) -> int | None:
             captured["timeout"] = timeout
             return None
 

--- a/tests/unit/cwsandbox/test_utilities.py
+++ b/tests/unit/cwsandbox/test_utilities.py
@@ -360,3 +360,8 @@ class TestExports:
     def test_set_auth_mode_in_all(self) -> None:
         """set_auth_mode is in __all__."""
         assert "set_auth_mode" in cwsandbox.__all__
+
+    def test_container_types_in_all(self) -> None:
+        assert "Container" in cwsandbox.__all__
+        assert "VolumeMount" in cwsandbox.__all__
+        assert "ContainerStatus" in cwsandbox.__all__


### PR DESCRIPTION
## Summary

A sandbox can run more than one container in the same pod. One container is the primary and owns the sandbox lifetime. Extra containers are helpers that share localhost and optional volumes. Exec, file read and write, logs, and an interactive shell can name a helper; omitting the name still hits the primary, so existing one-container calls keep working.

![Multi-container sandbox](https://github.com/user-attachments/assets/4dafb6ca-1a61-445c-97e5-cef23a951b33)

## What changed

### Create and types

Callers pass a list of containers on create and on session sandbox construction. More than one container requires exactly one primary, a name on every row, and resources on every row. GPU is allowed only on the primary. The list form cannot be mixed with the single-container image, command, args, resources, mounted files, secrets, pull credentials, or environment kwargs.

Volumes stay at sandbox scope. Sharing is two containers mounting the same volume name. A convenience mount path on a volume or snapshot option attaches to the primary only.

The existing command-and-args create path still sends one container named `main` and does not set the primary flag.

- `src/cwsandbox/_types.py` — container and volume-mount types, name rules, create validation
- `src/cwsandbox/_sandbox.py` — create, plus echo of the container list and per-container status
- `src/cwsandbox/_defaults.py` — shareable container list on defaults
- `src/cwsandbox/_session.py` — session sandbox accepts the list
- `src/cwsandbox/__init__.py` — public exports

### Targeting

Exec, read/write file, stream logs, and shell take an optional container name. Empty or omitted targets the primary.

- `src/cwsandbox/_sandbox.py` — container field on those RPCs
- CLI `exec`, `files`, `logs`, `sh` — `--container`
- CLI `get` — prints the container list and status

### API stubs

Vendored v1 stubs include the primary flag on each container.

### Docs

`AGENTS.md` documents the list form, targeting, and optional mount paths.

## Behavior / Key decisions

| Input | Outcome |
|---|---|
| Create with command and args (one container) | One container named `main`; primary flag unset |
| Create with a container list, more than one row | Exactly one primary; every row named and resourced |
| GPU on a non-primary row | Rejected at the client |
| Container name omitted on exec, files, logs, or shell | Primary |
| Container name set | That container |
| Volume with a mount path | Mounted on the primary |
| Volume without a mount path | Declared only; attach via each container's mounts |
| Container list plus image, command, or resources kwargs | `TypeError` |
| Create from a template with a container list | Replaces the template's container list |
| Remote function decorator | Still one container |

## Risk surface

One-container create, exec, files, and logs keep the same call shape. The public API reference generator needs the new exported types added to its manifest. A helper that never starts keeps the sandbox from reaching running. After a helper has started, a crash there does not fail the sandbox.

## Test plan

- [x] `uv run pytest tests/unit/cwsandbox/test_multi_container.py` plus the CLI, defaults, snapshot, sandbox, and utilities modules touched here — 642 passed
- [x] `uv run pytest tests/integration/cwsandbox/test_multi_container.py` against staging — 3 passed: named exec and files isolation, shared volume, Python primary reaching Redis on loopback

Not covered live: logs and shell targeting, CLI `--container`, templates, and session defaults.