### PR TITLE
fix(auth): harden credential handling in SandboxDefaults repr

### DIFF
--- a/src/cwsandbox/_defaults.py
+++ b/src/cwsandbox/_defaults.py
@@ -345,7 +345,7 @@ class SandboxDefaults:
     command: str = DEFAULT_COMMAND
     args: tuple[str, ...] = DEFAULT_ARGS
     base_url: str = DEFAULT_BASE_URL
-    auth: AuthConfig | None = None
+    auth: AuthConfig | None = field(default=None, repr=False)
     request_timeout_seconds: float = DEFAULT_REQUEST_TIMEOUT_SECONDS
     poll_retry_budget_seconds: float = DEFAULT_POLL_RETRY_BUDGET_SECONDS
     poll_rpc_timeout_seconds: float = DEFAULT_POLL_RPC_TIMEOUT_SECONDS

--- a/tests/unit/cwsandbox/test_defaults.py
+++ b/tests/unit/cwsandbox/test_defaults.py
@@ -10,6 +10,7 @@ import math
 import pytest
 
 from cwsandbox import (
+    AuthHeaders,
     DataPlaneMode,
     EgressRule,
     FileSystemSnapshotOptions,
@@ -76,6 +77,24 @@ class TestSandboxDefaults:
 
         with pytest.raises(dataclasses.FrozenInstanceError):
             defaults.container_image = "python:3.12"  # type: ignore[misc]
+
+    def test_repr_redacts_auth_credentials(self) -> None:
+        """Test repr does not expose resolved authentication credentials."""
+        sentinels = ("bearer-credential-sentinel", "wandb-credential-sentinel")
+        defaults = SandboxDefaults(
+            auth=AuthHeaders(
+                headers={
+                    "Authorization": f"Bearer {sentinels[0]}",
+                    "x-wandb-api-key": sentinels[1],
+                },
+                strategy="custom",
+            )
+        )
+
+        rendered = repr(defaults)
+
+        assert "auth=" not in rendered
+        assert all(sentinel not in rendered for sentinel in sentinels)
 
     def test_merge_tags_empty_base(self) -> None:
         """Test merge_tags with no default tags."""


### PR DESCRIPTION
## Summary

- harden auth credential handling by excluding SandboxDefaults.auth from the generated dataclass repr
- add regression coverage for bearer and W&B credential sentinels

Follow-up to #160.

## Testing

- 1,397 unit tests passed
- Ruff lint and formatting checks
- mypy
- docstring hygiene
- git diff --check