### PR TITLE
fix(sandbox): stop write fallback from waiting for stdin EOF

### DIFF
--- a/src/cwsandbox/_sandbox.py
+++ b/src/cwsandbox/_sandbox.py
@@ -7465,10 +7465,13 @@ class Sandbox:
         *,
         container: str | None = None,
     ) -> None:
+        # Counted read: do not wait for stdin EOF. Kubelet does not reliably
+        # deliver CLOSE, and the runner's stdin-close watchdog then aborts a
+        # silent `cat` with STDIN_CLOSE_GRACE_EXPIRED.
         script = (
             "path=$1\n"
             "expected=$2\n"
-            'if ! cat > "$path"; then\n'
+            'if ! head -c "$expected" > "$path"; then\n'
             '  printf "%s\\n" "Failed to write input stream to $path" >&2\n'
             "  exit 1\n"
             "fi\n"
@@ -7504,10 +7507,11 @@ class Sandbox:
             # would send the caller debugging the network instead of their code.
             raise
         except Exception as e:
-            # The exec-stream write does direct-cat-to-target (no temp file +
-            # rename), so any interruption — gRPC timeout, transport error,
-            # mid-stream cancel — may leave a partially written file. Surface
-            # that to callers so they can decide whether to retry vs delete.
+            # The exec-stream write writes directly to the target (no temp
+            # file + rename), so any interruption — gRPC timeout, transport
+            # error, mid-stream cancel — may leave a partially written file.
+            # Surface that to callers so they can decide whether to retry vs
+            # delete.
             raise SandboxFileError(
                 f"Failed to write file '{filepath}' via exec-stream fallback. "
                 f"The target may be partial or truncated. Upstream error: {e!r}",

--- a/tests/unit/cwsandbox/test_sandbox.py
+++ b/tests/unit/cwsandbox/test_sandbox.py
@@ -2347,6 +2347,30 @@ class TestSandboxFileOperationFallback:
         assert exc_info.value.filepath == "/tmp/out.bin"
         assert "partial or truncated" in str(exc_info.value)
 
+    def test_write_fallback_reads_expected_bytes_without_waiting_for_eof(self) -> None:
+        """The fallback already knows the payload size, so it must not use
+        ``cat`` (which blocks until stdin EOF). Kubelet CLOSE is unreliable
+        and a silent waiter is aborted by STDIN_CLOSE_GRACE_EXPIRED."""
+        sandbox = self._setup_running_sandbox()
+        payload = b"counted-write"
+
+        with patch.object(
+            sandbox,
+            "_exec_streaming_binary_async",
+            new_callable=AsyncMock,
+            return_value=(0, b"", b""),
+        ) as exec_binary:
+            sandbox._loop_manager.run_sync(
+                sandbox._write_file_via_exec_streaming("/tmp/out.bin", payload, 5.0)
+            )
+
+        command = exec_binary.await_args.args[0]
+        script = command[2]
+        assert command[:3] == ["/bin/sh", "-c", script]
+        assert command[3:] == ["cwsandbox-write-file", "/tmp/out.bin", str(len(payload))]
+        assert "head -c" in script
+        assert "cat >" not in script
+
 
 class TestSandboxFileTooLarge:
     """write_file / read_file dispatch around CWSANDBOX_FILE_TOO_LARGE.


### PR DESCRIPTION
## Summary

When a write is too large for a single file RPC, the client copies the bytes with a guest command. On main that command waits until stdin closes. If the guest never sees the close, the process stays silent, the runner aborts it after five seconds with `STDIN_CLOSE_GRACE_EXPIRED`, and the write fails. The fallback already knows how many bytes it sent, so it now reads that many bytes and exits. A short copy still fails the existing size check.

![Known-size write fallback](https://github.com/user-attachments/assets/7626df62-5af3-4b1c-a020-89498ad02a56)

## What changed

**Known-size write fallback.** The guest script that copies a buffered write now reads a fixed byte count instead of waiting for stdin EOF. The size check after the copy is unchanged.

- `src/cwsandbox/_sandbox.py` — guest script uses `head -c "$expected"`; comment updated to match.

**Unit coverage.** A test asserts the fallback command uses a counted read and still passes the payload length.

- `tests/unit/cwsandbox/test_sandbox.py` — `test_write_fallback_reads_expected_bytes_without_waiting_for_eof`

## Behavior / Key decisions

| Input | Outcome |
| --- | --- |
| Write fallback with a known payload length | Reads that many bytes, then checks the file size |
| Fewer bytes arrive than expected | Size check fails; same partial-file error as on main |
| Streaming write (length unknown) | Still uses `cat`; not in this PR |

`head -c` is the same class of guest tool as `cat` and `wc` (GNU, BSD, BusyBox). The default `python:3.11` image includes it.

## Risk surface

Only the known-size write fallback path. Public write and read APIs are unchanged. Guests without `head` would fail this fallback; that is the same coreutils assumption as today's `cat` / `wc` script. The streaming write API is unchanged and still depends on stdin close.

## Test plan

- [x] `uv run pytest tests/unit/cwsandbox/test_sandbox.py::TestSandboxFileOperationFallback` — 16 passed
- [ ] `tests/integration/cwsandbox/test_sandbox.py::test_sandbox_large_file_exec_fallback` against prod — not run in this session