### PR TITLE
test(e2e): fix runtime and file fallback checks

### DIFF
--- a/tests/integration/cwsandbox/test_sandbox.py
+++ b/tests/integration/cwsandbox/test_sandbox.py
@@ -207,6 +207,8 @@ def test_sandbox_large_file_exec_fallback(sandbox_defaults: SandboxDefaults) -> 
         self: Sandbox,
         filepath: str,
         timeout: float,
+        *,
+        container: str | None = None,
     ) -> bytes:
         raise SandboxResourceExhaustedError(
             "Read file resource exhausted: CLIENT: Received message larger than max"
@@ -590,7 +592,8 @@ def _required_runtime_class(sandbox_defaults: SandboxDefaults) -> str:
     """Runtime class the live fleet is required to admit.
 
     ``CWSANDBOX_TEST_RUNTIME_CLASS`` wins. Otherwise an unpinned create's
-    ``effective_runtime_class`` is the pin. Empty echo fails the environment.
+    named ``effective_runtime_class`` is the pin. Empty echo fails the
+    environment; the node-default sentinel skips explicit pin coverage.
     """
     pinned = os.environ.get("CWSANDBOX_TEST_RUNTIME_CLASS", "").strip()
     if pinned:
@@ -602,6 +605,11 @@ def _required_runtime_class(sandbox_defaults: SandboxDefaults) -> str:
         "Fleet did not echo an effective_runtime_class; "
         "set CWSANDBOX_TEST_RUNTIME_CLASS to a policy-admitted class"
     )
+    if admitted == "<node-default>":
+        pytest.skip(
+            "fleet uses the node-default runtime; set CWSANDBOX_TEST_RUNTIME_CLASS "
+            "to exercise an explicit runtime class"
+        )
     return admitted
 
 


### PR DESCRIPTION
## Summary

- accept the container-aware `_read_file_unary_async` signature in the large-file fallback test double
- skip explicit RuntimeClass pin coverage when an unpinned sandbox reports the `<node-default>` status sentinel
- continue exercising an explicit class whenever `CWSANDBOX_TEST_RUNTIME_CLASS` is configured or the fleet selects a named class

## Context

This fixes two failures found by the staging SDK E2E suite. `<node-default>` represents the absence of a named Kubernetes RuntimeClass and cannot be submitted as a valid create-time RuntimeClass value.

## Validation

- `uv run ruff format --check tests/integration/cwsandbox/test_sandbox.py`
- `uv run ruff check tests/integration/cwsandbox/test_sandbox.py`
- `uv run mypy src/`
- `uv run pytest` — 1,454 passed
- workflow-equivalent staging integration suite — 108 passed, 6 skipped
