### PR TITLE
fix(exec): retry transient direct failures

### DIFF
--- a/src/cwsandbox/_sandbox.py
+++ b/src/cwsandbox/_sandbox.py
@@ -1367,6 +1367,11 @@ def _is_resumable_transport_error(exc: BaseException) -> bool:
     return exc.code() in _STREAMING_RESUMABLE_STATUS_CODES
 
 
+def _is_retryable_transient_error(exc: CWSandboxError) -> bool:
+    """Return whether a translated failure belongs to the transient registry."""
+    return not isinstance(exc, SandboxNotFoundError) and isinstance(exc, _RETRYABLE_POLL_EXCEPTIONS)
+
+
 def _classify_poll_error(exc: CWSandboxError) -> _PollErrorClassification:
     """Classify a translated poll exception as retryable or fatal.
 
@@ -1374,11 +1379,7 @@ def _classify_poll_error(exc: CWSandboxError) -> _PollErrorClassification:
     that produced it - callers that receive ``SandboxNotFoundError`` have an
     authoritative "gone" signal and must not retry it at the poll level.
     """
-    if isinstance(exc, SandboxNotFoundError):
-        return "fatal"
-    if isinstance(exc, _RETRYABLE_POLL_EXCEPTIONS):
-        return "retryable"
-    return "fatal"
+    return "retryable" if _is_retryable_transient_error(exc) else "fatal"
 
 
 _T = TypeVar("_T")
@@ -6456,6 +6457,9 @@ class Sandbox:
         stdin_queue: asyncio.Queue[bytes | None] | None = None,
         stdin_writer: StreamWriter | None = None,
         container: str | None = None,
+        _retry_transient: bool = True,
+        _deadline: float | None = None,
+        _signal_completion: bool = True,
     ) -> ProcessResult:
         """Internal async: Execute command using StreamExec RPC, push output to queues.
 
@@ -6467,6 +6471,8 @@ class Sandbox:
         None in stdin_queue signals EOF. Uses done_writing() for proper half-close.
         """
         timeout = timeout_seconds if timeout_seconds is not None else self._request_timeout_seconds
+        if _deadline is None and timeout is not None:
+            _deadline = time.monotonic() + timeout
 
         if not command:
             raise ValueError("Command cannot be empty")
@@ -6622,6 +6628,9 @@ class Sandbox:
 
         # Start collector task (sender is handled by gRPC via the request_iterator)
         collect_task = asyncio.create_task(collect_responses())
+        received_response = False
+        retry_error: CWSandboxError | None = None
+        retry_timeout: float | None = None
 
         try:
             while True:
@@ -6629,9 +6638,21 @@ class Sandbox:
                 if item is None:
                     break
                 if isinstance(item, Exception):
+                    if (
+                        prepared.is_direct
+                        and _retry_transient
+                        and not received_response
+                        and isinstance(item, CWSandboxError)
+                        and _is_retryable_transient_error(item)
+                    ):
+                        retry_timeout = self._remaining_budget(_deadline)
+                        if retry_timeout is None or retry_timeout > 0:
+                            retry_error = item
+                            break
                     raise item
 
                 response = item
+                received_response = True
                 if response.HasField("ready"):
                     # Server ready to receive stdin data
                     # Log latency only when stdin is enabled (no overhead when stdin=False)
@@ -6684,12 +6705,40 @@ class Sandbox:
             collect_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await collect_task
-            # Signal stdin writer that process has exited (prevents writes to exited process)
-            if stdin_writer is not None:
-                stdin_writer.set_exception(SandboxExecutionError("Process has exited"))
-            # Signal end-of-stream
-            await stdout_queue.put(None)
-            await stderr_queue.put(None)
+            if retry_error is None and _signal_completion:
+                # Signal stdin writer that process has exited (prevents writes to exited process)
+                if stdin_writer is not None:
+                    stdin_writer.set_exception(SandboxExecutionError("Process has exited"))
+                # Signal end-of-stream
+                await stdout_queue.put(None)
+                await stderr_queue.put(None)
+
+        if retry_error is not None:
+            # A transient rejection before the runner emitted any frame is safe
+            # to replay. Drop the direct lease so the next preparation resolves
+            # the sandbox's current endpoint instead of reusing a stale channel.
+            await prepared.discard()
+            await prepared.release(discard=True)
+            try:
+                return await self._exec_streaming_async(
+                    command,
+                    stdout_queue,
+                    stderr_queue,
+                    cwd=cwd,
+                    check=check,
+                    timeout_seconds=retry_timeout,
+                    stdin_queue=stdin_queue,
+                    stdin_writer=stdin_writer,
+                    container=container,
+                    _retry_transient=False,
+                    _deadline=_deadline,
+                    _signal_completion=False,
+                )
+            finally:
+                if stdin_writer is not None:
+                    stdin_writer.set_exception(SandboxExecutionError("Process has exited"))
+                await stdout_queue.put(None)
+                await stderr_queue.put(None)
 
         # Propagate any error from request_generator (gRPC swallows generator exceptions)
         if request_error is not None:

--- a/tests/unit/cwsandbox/test_direct.py
+++ b/tests/unit/cwsandbox/test_direct.py
@@ -65,6 +65,68 @@ class _DirectRpcError(grpc.RpcError):
         return self._trailing
 
 
+class _DirectAioRpcError(grpc.aio.AioRpcError):
+    def __init__(
+        self,
+        code: grpc.StatusCode,
+        *,
+        reason: str | None = None,
+        details: str = "transient failure",
+    ) -> None:
+        self._code = code
+        self._details = details
+        self._trailing: list[tuple[str, bytes]] = []
+        if reason is not None:
+            info = error_details_pb2.ErrorInfo(
+                reason=reason,
+                domain="cwsandbox.com",
+            )
+            detail = any_pb2.Any()
+            detail.Pack(info)
+            status = status_pb2.Status(code=code.value[0], message=details)
+            status.details.append(detail)
+            self._trailing.append(("grpc-status-details-bin", status.SerializeToString()))
+
+    def code(self) -> grpc.StatusCode:
+        return self._code
+
+    def details(self) -> str:
+        return self._details
+
+    def initial_metadata(self) -> tuple[()]:
+        return ()
+
+    def trailing_metadata(self) -> list[tuple[str, bytes]]:
+        return self._trailing
+
+
+class _FakeExecCall:
+    def __init__(
+        self,
+        responses: list[sandbox_pb2.ExecStreamResponse] | None = None,
+        *,
+        error: Exception | None = None,
+    ) -> None:
+        self._responses = responses or []
+        self._error = error
+        self._index = 0
+        self.cancel = MagicMock()
+        self.add_done_callback = MagicMock()
+
+    def __aiter__(self) -> _FakeExecCall:
+        return self
+
+    async def __anext__(self) -> sandbox_pb2.ExecStreamResponse:
+        if self._index < len(self._responses):
+            response = self._responses[self._index]
+            self._index += 1
+            return response
+        if self._error is not None:
+            error, self._error = self._error, None
+            raise error
+        raise StopAsyncIteration
+
+
 def _connection_response(*permissions: int) -> sandbox_pb2.SandboxConnection:
     expires_at = Timestamp()
     expires_at.FromDatetime(datetime.now(UTC) + timedelta(hours=2))
@@ -425,6 +487,175 @@ async def test_retiring_direct_unary_discards_channel_and_retries_once() -> None
     first_lease.discard.assert_awaited_once()
     first_lease.release.assert_awaited_once_with(discard=True)
     second_lease.release.assert_awaited_once_with(discard=False)
+
+
+@pytest.mark.parametrize(
+    ("code", "reason", "details"),
+    [
+        pytest.param(
+            grpc.StatusCode.UNAVAILABLE,
+            "CWSANDBOX_RUNNER_SHARD_RETIRING",
+            "Runner shard is retiring; retry the operation on the current endpoint",
+            id="runner-shard-retiring-action-33802245090",
+        ),
+        pytest.param(
+            grpc.StatusCode.UNAVAILABLE,
+            None,
+            "connection lost",
+            id="bare-unavailable",
+        ),
+        pytest.param(
+            grpc.StatusCode.RESOURCE_EXHAUSTED,
+            None,
+            "runner overloaded",
+            id="resource-exhausted",
+        ),
+        pytest.param(
+            grpc.StatusCode.INTERNAL,
+            "CWSANDBOX_BACKEND_UNAVAILABLE",
+            "backend unavailable",
+            id="structured-backend-unavailable",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_direct_exec_retries_transient_error_before_first_response(
+    code: grpc.StatusCode,
+    reason: str | None,
+    details: str,
+) -> None:
+    sandbox = _running_sandbox(DataPlaneMode.DIRECT)
+    first_stub = MagicMock()
+    first_stub.StreamExec = MagicMock(
+        return_value=_FakeExecCall(error=_DirectAioRpcError(code, reason=reason, details=details))
+    )
+    second_stub = MagicMock()
+    second_stub.StreamExec = MagicMock(
+        return_value=_FakeExecCall(
+            [
+                sandbox_pb2.ExecStreamResponse(
+                    output=sandbox_pb2.ExecStreamOutput(
+                        stream=sandbox_pb2.ExecStreamOutput.STREAM_STDOUT,
+                        data=b"ok\n",
+                    )
+                ),
+                sandbox_pb2.ExecStreamResponse(exit=sandbox_pb2.ExecStreamExit(exit_code=0)),
+            ]
+        )
+    )
+    first_lease = MagicMock(stub=first_stub)
+    first_lease.release = AsyncMock()
+    first_lease.discard = AsyncMock()
+    second_lease = MagicMock(stub=second_stub)
+    second_lease.release = AsyncMock()
+    second_lease.discard = AsyncMock()
+    sandbox._direct_data_plane.acquire = AsyncMock(side_effect=[first_lease, second_lease])
+    stdout_queue: asyncio.Queue[str | Exception | None] = asyncio.Queue()
+    stderr_queue: asyncio.Queue[str | Exception | None] = asyncio.Queue()
+
+    with (
+        patch.object(sandbox, "_ensure_started_async", AsyncMock()),
+        patch.object(sandbox, "_wait_until_running_async", AsyncMock()),
+        patch.object(sandbox, "_ensure_client", AsyncMock()),
+    ):
+        result = await sandbox._exec_streaming_async(["echo", "ok"], stdout_queue, stderr_queue)
+
+    assert result.stdout == "ok\n"
+    assert sandbox._direct_data_plane.acquire.await_count == 2
+    first_lease.discard.assert_awaited_once()
+    first_lease.release.assert_awaited_once_with(discard=True)
+    assert await stdout_queue.get() == "ok\n"
+    assert await stdout_queue.get() is None
+    assert await stderr_queue.get() is None
+
+
+@pytest.mark.asyncio
+async def test_direct_exec_retries_transient_error_only_once() -> None:
+    sandbox = _running_sandbox(DataPlaneMode.DIRECT)
+    leases = []
+    for _ in range(2):
+        stub = MagicMock()
+        stub.StreamExec = MagicMock(
+            return_value=_FakeExecCall(error=_DirectAioRpcError(grpc.StatusCode.UNAVAILABLE))
+        )
+        lease = MagicMock(stub=stub)
+        lease.release = AsyncMock()
+        lease.discard = AsyncMock()
+        leases.append(lease)
+    sandbox._direct_data_plane.acquire = AsyncMock(side_effect=leases)
+    stdout_queue: asyncio.Queue[str | Exception | None] = asyncio.Queue()
+    stderr_queue: asyncio.Queue[str | Exception | None] = asyncio.Queue()
+
+    with (
+        patch.object(sandbox, "_ensure_started_async", AsyncMock()),
+        patch.object(sandbox, "_wait_until_running_async", AsyncMock()),
+        patch.object(sandbox, "_ensure_client", AsyncMock()),
+        pytest.raises(SandboxUnavailableError),
+    ):
+        await sandbox._exec_streaming_async(["echo", "ok"], stdout_queue, stderr_queue)
+
+    assert sandbox._direct_data_plane.acquire.await_count == 2
+    leases[0].discard.assert_awaited_once()
+    leases[0].release.assert_awaited_once_with(discard=True)
+    assert stdout_queue.qsize() == 1
+    assert await stdout_queue.get() is None
+    assert await stderr_queue.get() is None
+
+
+@pytest.mark.asyncio
+async def test_direct_exec_retry_connection_failure_closes_streams() -> None:
+    sandbox = _running_sandbox(DataPlaneMode.DIRECT)
+    stub = MagicMock()
+    stub.StreamExec = MagicMock(
+        return_value=_FakeExecCall(error=_DirectAioRpcError(grpc.StatusCode.UNAVAILABLE))
+    )
+    lease = MagicMock(stub=stub)
+    lease.release = AsyncMock()
+    lease.discard = AsyncMock()
+    sandbox._direct_data_plane.acquire = AsyncMock(
+        side_effect=[lease, DirectDataPlaneUnavailable("replacement unavailable")]
+    )
+    stdout_queue: asyncio.Queue[str | Exception | None] = asyncio.Queue()
+    stderr_queue: asyncio.Queue[str | Exception | None] = asyncio.Queue()
+
+    with (
+        patch.object(sandbox, "_ensure_started_async", AsyncMock()),
+        patch.object(sandbox, "_wait_until_running_async", AsyncMock()),
+        patch.object(sandbox, "_ensure_client", AsyncMock()),
+        pytest.raises(SandboxUnavailableError, match="replacement unavailable"),
+    ):
+        await sandbox._exec_streaming_async(["echo", "ok"], stdout_queue, stderr_queue)
+
+    assert await stdout_queue.get() is None
+    assert await stderr_queue.get() is None
+
+
+@pytest.mark.asyncio
+async def test_direct_exec_does_not_retry_after_first_response() -> None:
+    sandbox = _running_sandbox(DataPlaneMode.DIRECT)
+    stub = MagicMock()
+    stub.StreamExec = MagicMock(
+        return_value=_FakeExecCall(
+            [sandbox_pb2.ExecStreamResponse(ready=sandbox_pb2.ExecStreamReady())],
+            error=_DirectAioRpcError(grpc.StatusCode.UNAVAILABLE),
+        )
+    )
+    lease = MagicMock(stub=stub)
+    lease.release = AsyncMock()
+    lease.discard = AsyncMock()
+    sandbox._direct_data_plane.acquire = AsyncMock(return_value=lease)
+    stdout_queue: asyncio.Queue[str | Exception | None] = asyncio.Queue()
+    stderr_queue: asyncio.Queue[str | Exception | None] = asyncio.Queue()
+
+    with (
+        patch.object(sandbox, "_ensure_started_async", AsyncMock()),
+        patch.object(sandbox, "_wait_until_running_async", AsyncMock()),
+        patch.object(sandbox, "_ensure_client", AsyncMock()),
+        pytest.raises(SandboxUnavailableError),
+    ):
+        await sandbox._exec_streaming_async(["echo", "ok"], stdout_queue, stderr_queue)
+
+    sandbox._direct_data_plane.acquire.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- retry translated transient direct-data-plane failures once when `StreamExec` fails before the first server response
- discard the failed lease so retry resolves the sandbox current endpoint
- preserve the original exec timeout budget and do not replay after any server frame
- keep stdout, stderr, and stdin lifecycle signals correct across retry and replacement-connection failure

## Regression coverage

Mocks the exact failure from our e2e testing: gRPC `UNAVAILABLE` with AIP-193 reason `CWSANDBOX_RUNNER_SHARD_RETIRING` and detail `Runner shard is retiring; retry the operation on the current endpoint`. Also covers bare `UNAVAILABLE`, `RESOURCE_EXHAUSTED`, structured `CWSANDBOX_BACKEND_UNAVAILABLE`, the one-retry cap, no retry after the first response, and replacement connection failure.

## Validation

- `mise run test` (1461 passed)
- `mise run typecheck`
- `mise run lint`