### PR TITLE
fix: match from-file spillover errors and pin PREPARING wait

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,7 +187,7 @@ data = ref.result()               # Block when result needed
 data = await ref
 ```
 
-**`SandboxStatus`** (`_sandbox.py`): StrEnum for sandbox lifecycle states. Lifecycle: `CREATING` -> `RUNNING` -> `TERMINATING` -> `COMPLETED` | `FAILED`. Values: `PENDING`, `CREATING`, `PREPARING` (accepted image fill; Gateway does not insert these rows yet; `wait()` polls through it), `RUNNING`, `PAUSED`, `TERMINATING`, `COMPLETED`, `FAILED`, `TERMINATED` (deprecated), `UNSPECIFIED`. `TERMINATING` is non-terminal: the sandbox is draining through its grace period. `TERMINATED` is deprecated in favor of the `TERMINATING` -> `COMPLETED`/`FAILED` flow but still emitted by older backends. Terminal statuses (used for caching and polling): `COMPLETED`, `FAILED`, `TERMINATED`. Methods `from_proto()` and `to_proto()` for protobuf conversion.
+**`SandboxStatus`** (`_sandbox.py`): StrEnum for sandbox lifecycle states. Lifecycle: `CREATING` | `PREPARING` -> `RUNNING` -> `TERMINATING` -> `COMPLETED` | `FAILED`. Values: `PENDING`, `CREATING`, `PREPARING` (accepted image fill; Gateway does not insert these rows yet; `wait()` polls through it), `RUNNING`, `PAUSED`, `TERMINATING`, `COMPLETED`, `FAILED`, `TERMINATED` (deprecated), `UNSPECIFIED`. `TERMINATING` is non-terminal: the sandbox is draining through its grace period. `TERMINATED` is deprecated in favor of the `TERMINATING` -> `COMPLETED`/`FAILED` flow but still emitted by older backends. Terminal statuses (used for caching and polling): `COMPLETED`, `FAILED`, `TERMINATED`. Methods `from_proto()` and `to_proto()` for protobuf conversion.
 
 **Exec Types** (`_types.py`): Types for command execution, returned by `Sandbox.exec()`:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # CHANGELOG
 
 
+## Unreleased
+
+### Bug Fixes
+
+- **sandbox**: Raise ValueError for non-strict `run_from_file()` spillover
+
+  `run_from_file(placement_spillover=...)` now raises `ValueError` when the
+  value is not `strict`, matching template creates. A non-strict value on
+  `SandboxDefaults` is still ignored.
+
+### Documentation
+
+- **sandbox**: Mention `PREPARING` on the `SandboxStatus` lifecycle line
+
+
 ## v1.14.1 (2026-09-04)
 
 ### Bug Fixes

--- a/src/cwsandbox/_sandbox.py
+++ b/src/cwsandbox/_sandbox.py
@@ -286,7 +286,7 @@ class _PreparedDataPlaneCall:
 class SandboxStatus(StrEnum):
     """Sandbox lifecycle status values.
 
-    Lifecycle: CREATING -> RUNNING -> TERMINATING -> COMPLETED | FAILED
+    Lifecycle: CREATING | PREPARING -> RUNNING -> TERMINATING -> COMPLETED | FAILED
 
     Attributes:
         PENDING: Sandbox has been accepted but not yet scheduled.
@@ -1118,8 +1118,8 @@ def _resolve_placement_for_spillover(
     creates only allow ``STRICT``.
     """
     if from_file and spillover != PlacementSpillover.STRICT:
-        raise TypeError(
-            f"placement_spillover must be 'strict' for run_from_file (got {spillover.value!r})"
+        raise ValueError(
+            f"placement_spillover must be STRICT for run_from_file (got {spillover.value!r})"
         )
     if from_template and spillover != PlacementSpillover.STRICT:
         raise ValueError(
@@ -2470,7 +2470,8 @@ class Sandbox:
                 ``placement_mode``, ``runner_ids``, annotations, object-storage
                 access, and max lifetime are inherited. Container/volume/
                 service defaults are not. Non-strict ``placement_spillover``
-                on defaults is ignored (from-file is always strict).
+                on defaults is ignored (from-file is always strict). An
+                explicit non-strict keyword argument raises.
             request_id: Optional idempotency token. Auto-generated when omitted.
             **kwargs: Rejected. This RPC does not accept volumes, published
                 services, ``runtime_class``, ``image_pull_credentials``,

--- a/tests/unit/cwsandbox/test_sandbox.py
+++ b/tests/unit/cwsandbox/test_sandbox.py
@@ -1262,12 +1262,23 @@ class TestSandboxRun:
             )
 
     def test_run_from_file_rejects_non_strict_spillover(self) -> None:
-        with pytest.raises(TypeError, match="must be 'strict'"):
+        with pytest.raises(ValueError, match="must be STRICT"):
             Sandbox.run_from_file(
                 b"services:\n  main:\n    image: python:3.11\n",
                 primary_service="main",
                 placement_spillover=PlacementSpillover.CKS_THEN_SERVERLESS,
             )
+
+    def test_run_from_file_ignores_non_strict_spillover_on_defaults(self) -> None:
+        sandbox, _stub = self._run_from_file_with_mock_stub(
+            b"services:\n  main:\n    image: python:3.11\n",
+            primary_service="main",
+            defaults=SandboxDefaults(
+                placement_spillover=PlacementSpillover.CKS_THEN_SERVERLESS,
+            ),
+        )
+        assert sandbox._placement_spillover == PlacementSpillover.STRICT
+        sandbox._state = _Terminal(sandbox_id="from-file-id", status=SandboxStatus.COMPLETED)
 
     def test_run_from_file_defaults_file_type_compose(self) -> None:
         from cwsandbox._proto import sandbox_pb2
@@ -3819,6 +3830,40 @@ class TestSandboxWaitForRunning:
             sandbox.wait()
 
             assert sandbox.returncode == 0
+
+    def test_wait_polls_through_preparing(self) -> None:
+        """wait() keeps polling while proto state is PREPARING.
+
+        STATE_PREPARING used to map to UNSPECIFIED, which is a stable poll
+        result and made wait() return before the sandbox was ready.
+        """
+        from cwsandbox._proto import sandbox_pb2
+
+        sandbox = Sandbox(command="sleep", args=["infinity"])
+        sandbox._sandbox_id = "preparing-id"
+        sandbox._state = _Starting(sandbox_id="preparing-id")
+
+        preparing = sandbox_pb2.Sandbox(
+            sandbox_id="preparing-id",
+            status=sandbox_pb2.SandboxStatus(state=sandbox_pb2.STATE_PREPARING),
+        )
+        running = sandbox_pb2.Sandbox(
+            sandbox_id="preparing-id",
+            status=sandbox_pb2.SandboxStatus(
+                state=sandbox_pb2.STATE_RUNNING,
+                runner_id="tower-1",
+            ),
+        )
+
+        with patch.object(sandbox, "_ensure_client", new_callable=AsyncMock):
+            sandbox._channel = MagicMock()
+            sandbox._stub = MagicMock()
+            sandbox._stub.GetSandbox = AsyncMock(side_effect=[preparing, running])
+            with patch("cwsandbox._sandbox.asyncio.sleep", new_callable=AsyncMock):
+                sandbox.wait()
+
+        assert sandbox.status == SandboxStatus.RUNNING
+        assert sandbox._stub.GetSandbox.await_count == 2
 
 
 class TestSandboxEnvironmentVariables:


### PR DESCRIPTION
## Summary

Creating a sandbox from a Compose file now raises ValueError, not TypeError, when placement spillover is not strict — the same exception template creates already use. A non-strict spillover on shared defaults is still ignored. Waiting for the sandbox to be ready now has a unit test that keeps polling through the preparing state until the sandbox is running, and the status lifecycle line names that state.

This is the follow-up for the review on #170.

## Details

| Case | On main | This PR |
| --- | --- | --- |
| Explicit non-strict spillover on Compose create | `TypeError` | `ValueError` |
| Non-strict spillover on shared defaults | Ignored | Still ignored; the docstring now says the keyword still raises |
| `wait()` while status is preparing | Enum membership only | Poll mock: preparing, then running |

## Test plan

- [x] Unit tests for Compose-create spillover reject/ignore and `wait()` polling through preparing (16 related tests passed)
- [ ] CI